### PR TITLE
Fix minor typo in window-features-and-custom-features

### DIFF
--- a/docs/user_guides/window-features-and-custom-features.ipynb
+++ b/docs/user_guides/window-features-and-custom-features.ipynb
@@ -126,7 +126,7 @@
    "id": "3d439250",
    "metadata": {},
    "source": [
-    "The <code>RollingFeatures</code> class available is skforecast allows the creation of some of the most commonly used predictors:\n",
+    "The <code>RollingFeatures</code> class available in skforecast allows the creation of some of the most commonly used predictors:\n",
     "\n",
     "+ 'mean': the mean of the previous *n* values.\n",
     "+ 'std': the standard deviation of the previous *n* values.\n",


### PR DESCRIPTION
Minor typo in RollingFeatures section. Changed "is" to "in".