### PR TITLE
Fix minor typo in user_guides

### DIFF
--- a/docs/user_guides/table-of-contents.md
+++ b/docs/user_guides/table-of-contents.md
@@ -7,7 +7,7 @@ Welcome to the skforecast user guides! This comprehensive collection of guides i
 - [Recursive multi-step forecasting](../user_guides/autoregresive-forecaster.html)
 - [Direct multi-step forecasting](../user_guides/direct-multi-step-forecasting.html)
 - [ARIMA and SARIMAX forecasting](../user_guides/forecasting-sarimax-arima.html)
-- [Foreasting baseline](../user_guides/forecasting-baseline.html)
+- [Forecasting baseline](../user_guides/forecasting-baseline.html)
 
 <span style="font-size: 1.3em;">Global Forecasters (multiple series)</span>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ nav:
       - Recursive multi-step forecasting: user_guides/autoregresive-forecaster.ipynb
       - Direct multi-step forecasting: user_guides/direct-multi-step-forecasting.ipynb
       - ARIMA and SARIMAX forecasting: user_guides/forecasting-sarimax-arima.ipynb
-      - Foreasting baseline: user_guides/forecasting-baseline.ipynb
+      - Forecasting baseline: user_guides/forecasting-baseline.ipynb
     - Global Forecasters (multiple series):
       - Independent multi-time series forecasting: user_guides/independent-multi-time-series-forecasting.ipynb
       - Series with different lengths and different exogenous variables: user_guides/multi-series-with-different-length-and-different_exog.ipynb


### PR DESCRIPTION
Minor typo in user guide table of contents: 
<img width="456" alt="image" src="https://github.com/user-attachments/assets/e2aeddc9-61a5-4be8-8265-50fc76d1adfb" />
