### PR TITLE
Fix forecaster rnn predict outputs

### DIFF
--- a/skforecast/deep_learning/_forecaster_rnn.py
+++ b/skforecast/deep_learning/_forecaster_rnn.py
@@ -995,6 +995,20 @@ class ForecasterRnn(ForecasterBase):
 
             boot_predictions[level] = boot_level
 
+        # Temporal standardization. Pending full code refactoring:
+        boot_predictions = (
+            pd.concat([value.assign(level=key) for key, value in boot_predictions.items()])
+            .reset_index()
+            .sort_values(by=["index", "level"])
+            .set_index("index")
+            .rename_axis(None, axis=0)
+        )
+        boot_predictions = boot_predictions[
+            ["level"] + [col for col in boot_predictions.columns if col not in ["level", "index"]]
+            ]
+        if isinstance(boot_predictions.index, pd.DatetimeIndex) and boot_predictions.index.freq is not None:
+            boot_predictions.index.freq = None
+
         set_skforecast_warnings(suppress_warnings, action='default')
 
         return boot_predictions

--- a/skforecast/deep_learning/_forecaster_rnn.py
+++ b/skforecast/deep_learning/_forecaster_rnn.py
@@ -791,6 +791,15 @@ class ForecasterRnn(ForecasterBase):
             )
             predictions.loc[:, serie] = x
 
+        # Temporal standardization. Pending full refactoring
+        predictions = (
+            predictions.melt(var_name="level", value_name="pred", ignore_index=False)
+            .reset_index()
+            .sort_values(by=["index", "level"])
+            .set_index("index")
+            .rename_axis(None, axis=0)
+        )
+
         set_skforecast_warnings(suppress_warnings, action="default")
 
         return predictions

--- a/skforecast/deep_learning/tests/tests_forecaster_rnn/test_predict.py
+++ b/skforecast/deep_learning/tests/tests_forecaster_rnn/test_predict.py
@@ -50,7 +50,7 @@ def test_predict_3_steps_ahead():
     predictions = forecaster.predict(steps=3)
 
     # Check the shape and values of the predictions
-    assert predictions.shape == (3, 2)
+    assert predictions.shape == (6, 2)
 
 
 # Test case for predicting 2 steps ahead with specific levels
@@ -66,4 +66,4 @@ def test_predict_2_steps_ahead_specific_levels():
     predictions = forecaster.predict(steps=3, levels="1")
 
     # Check the shape and values of the predictions
-    assert predictions.shape == (3, 1)
+    assert predictions.shape == (3, 2)

--- a/skforecast/deep_learning/tests/tests_forecaster_rnn/test_predict_bootstrapping.py
+++ b/skforecast/deep_learning/tests/tests_forecaster_rnn/test_predict_bootstrapping.py
@@ -49,9 +49,7 @@ def test_predict_bootstrapping_output_size_with_steps_by_default():
     boot_preds = forecaster.predict_bootstrapping()
 
     # Check the shape and values of the predictions
-    assert list(boot_preds.keys()) == levels
-    for level in levels:
-        assert boot_preds[level].shape == (steps, 250)
+    assert boot_preds.shape == (steps * len(levels), 251)
 
 
 def test_predict_bootstrapping_output_size_3_steps_ahead():
@@ -66,9 +64,7 @@ def test_predict_bootstrapping_output_size_3_steps_ahead():
     boot_preds = forecaster.predict_bootstrapping(steps=3)
 
     # Check the shape and values of the predictions
-    assert list(boot_preds.keys()) == levels
-    for level in levels:
-        assert boot_preds[level].shape == (3, 250)
+    assert boot_preds.shape == (3 * len(levels), 251)
 
 
 def test_predict_2_steps_ahead_specific_levels():
@@ -83,6 +79,5 @@ def test_predict_2_steps_ahead_specific_levels():
     boot_preds = forecaster.predict_bootstrapping(steps=2, levels="1")
 
     # Check the shape and values of the predictions
-    assert list(boot_preds.keys()) == ["1"]
-    for level in list(boot_preds.keys()):
-        assert boot_preds[level].shape == (2, 250)
+    assert boot_preds.shape == (2 * 1, 251)
+

--- a/skforecast/deep_learning/tests/tests_forecaster_rnn/test_predict_bootstrapping_pytorch.py
+++ b/skforecast/deep_learning/tests/tests_forecaster_rnn/test_predict_bootstrapping_pytorch.py
@@ -53,9 +53,7 @@ def test_predict_bootstrapping_output_size_with_steps_by_default():
     boot_preds = forecaster.predict_bootstrapping()
 
     # Check the shape and values of the predictions
-    assert list(boot_preds.keys()) == levels
-    for level in levels:
-        assert boot_preds[level].shape == (steps, 250)
+    assert boot_preds.shape == (steps * len(levels), 251)
 
 
 def test_predict_bootstrapping_output_size_3_steps_ahead():
@@ -70,9 +68,7 @@ def test_predict_bootstrapping_output_size_3_steps_ahead():
     boot_preds = forecaster.predict_bootstrapping(steps=3)
 
     # Check the shape and values of the predictions
-    assert list(boot_preds.keys()) == levels
-    for level in levels:
-        assert boot_preds[level].shape == (3, 250)
+    assert boot_preds.shape == (3 * len(levels), 251)
 
 
 def test_predict_2_steps_ahead_specific_levels():
@@ -87,6 +83,4 @@ def test_predict_2_steps_ahead_specific_levels():
     boot_preds = forecaster.predict_bootstrapping(steps=2, levels="1")
 
     # Check the shape and values of the predictions
-    assert list(boot_preds.keys()) == ["1"]
-    for level in list(boot_preds.keys()):
-        assert boot_preds[level].shape == (2, 250)
+    assert boot_preds.shape == (2 * 1, 251)

--- a/skforecast/deep_learning/tests/tests_forecaster_rnn/test_predict_pytorch.py
+++ b/skforecast/deep_learning/tests/tests_forecaster_rnn/test_predict_pytorch.py
@@ -55,7 +55,7 @@ def test_predict_3_steps_ahead():
     predictions = forecaster.predict(steps=3)
 
     # Check the shape and values of the predictions
-    assert predictions.shape == (3, 2)
+    assert predictions.shape == (6, 2)
 
 
 # Test case for predicting 2 steps ahead with specific levels
@@ -71,4 +71,4 @@ def test_predict_2_steps_ahead_specific_levels():
     predictions = forecaster.predict(steps=3, levels="1")
 
     # Check the shape and values of the predictions
-    assert predictions.shape == (3, 1)
+    assert predictions.shape == (3, 2)


### PR DESCRIPTION
Working on predict_interval() implementation, I noticed some differences between `ForecasterRNN` and `ForecasterRecursiveMultiSeries` prediction outputs. I've standardized these outputs for `ForecasterRNN` using (as a temporal fix) some code lines from multiseries fixtures.

After this fix, rest of predict methods should have a direct implementation. We'll come back to `predict` and `predict_bootstrapping` methods to do a complete refactoring.