### PR TITLE
Keep NaN last-window levels for NaN-tolerant estimators (#1196)

### DIFF
--- a/skforecast/model_selection/_utils.py
+++ b/skforecast/model_selection/_utils.py
@@ -22,6 +22,7 @@ from ..utils import (
     check_interval,
     date_to_index_position,
     cast_catboost_categorical_columns_dataframe,
+    estimator_has_native_nan_support,
 )
 
 
@@ -906,6 +907,8 @@ def _extract_data_folds_multiseries(
     window_size: int,
     exog: pd.Series | pd.DataFrame | dict[str, pd.Series | pd.DataFrame] | None = None,
     dropna_last_window: bool = False,
+    estimator: object | None = None,
+    differentiation: int | dict[str, int | None] | None = None,
     externally_fitted: bool = False
 ) -> Generator[
         tuple[
@@ -937,7 +940,19 @@ def _extract_data_folds_multiseries(
     exog : pandas Series, pandas DataFrame, dict, default None
         Exogenous variables.
     dropna_last_window : bool, default False
-        If `True`, drop the columns of the last window that have NaN values.
+        If `True`, drop levels (columns) whose last window contains NaN values,
+        unless `estimator` natively supports NaN inputs and `differentiation`
+        is `None`. When the estimator supports NaNs and no differentiation is
+        used, levels with NaNs in the last window are kept. Differentiation is
+        always a hard exclusion: if set, levels with any NaN are dropped even
+        for NaN-tolerant estimators.
+    estimator : object, default None
+        Estimator used by the forecaster. Used to decide whether levels with
+        NaNs in the last window can be kept when `dropna_last_window=True`.
+        If the estimator is a Pipeline, the last step is inspected.
+    differentiation : int, dict, default None
+        Differentiation order of the forecaster. If not `None`, levels with
+        NaNs in the last window are always dropped when `dropna_last_window=True`.
     externally_fitted : bool, default False
         Flag indicating whether the forecaster is already trained. Only used when 
         `initial_train_size` is None and `refit` is False.
@@ -1022,19 +1037,19 @@ def _extract_data_folds_multiseries(
             series_last_window = pd.DataFrame(series_last_window)
 
         if dropna_last_window:
-            series_last_window = series_last_window.dropna(axis=1, how="any")
-            # TODO: when dropna_last_window is True, allow keeping levels whose last
-            # window contains NaNs when the estimator natively supports NaN inputs
-            # (reuse the module-based family detection in
-            # utils.configure_estimator_categorical_features:
-            # lightgbm/catboost/xgboost/sklearn-HistGradientBoosting; unwrap Pipeline
-            # first). RollingFeatures already tolerates NaNs in the window, so only
-            # raw lag predictors need the estimator's NaN support. Differentiation
-            # must be a hard exclusion (keep the current dropna(how="any")): np.diff
-            # expands the NaN footprint in the lags and inverse_transform_next_window
-            # uses cumsum, so a single NaN poisons the whole horizon for that level.
-            # The existing MissingValuesWarning in check_predict_input already covers
-            # the NaN-last-window case, so no extra warning is needed.
+            # Keep levels with NaNs only when the estimator natively supports
+            # NaN inputs and differentiation is not used. Differentiation is a
+            # hard exclusion: np.diff expands the NaN footprint and
+            # inverse_transform_next_window propagates a single NaN across the
+            # forecast horizon. MissingValuesWarning in check_predict_input
+            # already covers NaN last-window cases.
+            keep_nan_levels = (
+                estimator is not None
+                and differentiation is None
+                and estimator_has_native_nan_support(estimator)
+            )
+            if not keep_nan_levels:
+                series_last_window = series_last_window.dropna(axis=1, how="any")
         
         levels_last_window = list(series_last_window.columns)
 

--- a/skforecast/model_selection/_validation.py
+++ b/skforecast/model_selection/_validation.py
@@ -1280,6 +1280,8 @@ def _backtesting_forecaster_multiseries(
                         window_size        = forecaster.window_size,
                         exog               = exog,
                         dropna_last_window = forecaster.dropna_from_series,
+                        estimator          = getattr(forecaster, "estimator", None),
+                        differentiation    = getattr(forecaster, "differentiation", None),
                         externally_fitted  = False
                     )
         series_train, _, last_window_levels, exog_train, _, _ = next(data_fold)
@@ -1320,6 +1322,8 @@ def _backtesting_forecaster_multiseries(
                      window_size        = forecaster.window_size,
                      exog               = exog,
                      dropna_last_window = forecaster.dropna_from_series,
+                     estimator          = getattr(forecaster, "estimator", None),
+                     differentiation    = getattr(forecaster, "differentiation", None),
                      externally_fitted  = externally_fitted
                  )
 

--- a/skforecast/model_selection/tests/tests_utils/test_extract_data_folds_multiseries.py
+++ b/skforecast/model_selection/tests/tests_utils/test_extract_data_folds_multiseries.py
@@ -698,3 +698,127 @@ def test_extract_data_folds_multiseries_series_dict_exog_dict_DatetimeIndex_with
                     pd.testing.assert_series_equal(data_fold[4][key], expected_data_folds[i][4][key])
 
         assert data_fold[5] == expected_data_folds[i][5]
+
+
+def _series_with_nan_in_last_window_fold0():
+    """Series fixture with a single NaN in l2 inside fold-0 last window."""
+    series_nan = series_wide_range.copy()
+    series_nan.loc[28, 'l2'] = np.nan
+    series_nan.index = pd.date_range(start='2020-01-01', periods=50, freq='D')
+    return series_nan
+
+
+def test_extract_data_folds_multiseries_keeps_nan_level_for_nan_tolerant_estimator():
+    """
+    When dropna_last_window=True and the estimator natively supports NaNs
+    (and differentiation is None), keep levels with NaNs in the last window.
+    """
+    from sklearn.ensemble import HistGradientBoostingRegressor
+
+    folds = [[0, [0, 30], [25, 30], [30, 37], True]]
+    span_index = pd.date_range(start='2020-01-01', periods=50, freq='D')
+
+    data_fold = next(
+        _extract_data_folds_multiseries(
+            series             = _series_with_nan_in_last_window_fold0(),
+            folds              = folds,
+            span_index         = span_index,
+            window_size        = 5,
+            exog               = None,
+            dropna_last_window = True,
+            estimator          = HistGradientBoostingRegressor(),
+            differentiation    = None,
+            externally_fitted  = False
+        )
+    )
+
+    assert data_fold[2] == ['l1', 'l2', 'l3']
+    assert data_fold[1]['l2'].isna().sum() == 1
+
+
+def test_extract_data_folds_multiseries_drops_nan_level_for_non_tolerant_estimator():
+    """
+    When dropna_last_window=True and the estimator does not support NaNs,
+    drop levels with any NaN in the last window.
+    """
+    from sklearn.linear_model import LinearRegression
+
+    folds = [[0, [0, 30], [25, 30], [30, 37], True]]
+    span_index = pd.date_range(start='2020-01-01', periods=50, freq='D')
+
+    data_fold = next(
+        _extract_data_folds_multiseries(
+            series             = _series_with_nan_in_last_window_fold0(),
+            folds              = folds,
+            span_index         = span_index,
+            window_size        = 5,
+            exog               = None,
+            dropna_last_window = True,
+            estimator          = LinearRegression(),
+            differentiation    = None,
+            externally_fitted  = False
+        )
+    )
+
+    assert data_fold[2] == ['l1', 'l3']
+    assert list(data_fold[1].columns) == ['l1', 'l3']
+
+
+def test_extract_data_folds_multiseries_drops_nan_level_when_differentiation_set():
+    """
+    Differentiation is a hard exclusion: even with a NaN-tolerant estimator,
+    levels with NaNs in the last window are dropped.
+    """
+    from sklearn.ensemble import HistGradientBoostingRegressor
+
+    folds = [[0, [0, 30], [25, 30], [30, 37], True]]
+    span_index = pd.date_range(start='2020-01-01', periods=50, freq='D')
+
+    data_fold = next(
+        _extract_data_folds_multiseries(
+            series             = _series_with_nan_in_last_window_fold0(),
+            folds              = folds,
+            span_index         = span_index,
+            window_size        = 5,
+            exog               = None,
+            dropna_last_window = True,
+            estimator          = HistGradientBoostingRegressor(),
+            differentiation    = 1,
+            externally_fitted  = False
+        )
+    )
+
+    assert data_fold[2] == ['l1', 'l3']
+    assert list(data_fold[1].columns) == ['l1', 'l3']
+
+
+def test_extract_data_folds_multiseries_keeps_nan_level_for_pipeline_nan_tolerant_estimator():
+    """
+    Pipeline estimators are unwrapped: NaN support is based on the last step.
+    """
+    from sklearn.ensemble import HistGradientBoostingRegressor
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+
+    folds = [[0, [0, 30], [25, 30], [30, 37], True]]
+    span_index = pd.date_range(start='2020-01-01', periods=50, freq='D')
+    estimator = Pipeline([
+        ("scaler", StandardScaler()),
+        ("model", HistGradientBoostingRegressor()),
+    ])
+
+    data_fold = next(
+        _extract_data_folds_multiseries(
+            series             = _series_with_nan_in_last_window_fold0(),
+            folds              = folds,
+            span_index         = span_index,
+            window_size        = 5,
+            exog               = None,
+            dropna_last_window = True,
+            estimator          = estimator,
+            differentiation    = None,
+            externally_fitted  = False
+        )
+    )
+
+    assert data_fold[2] == ['l1', 'l2', 'l3']

--- a/skforecast/recursive/_forecaster_recursive_multiseries.py
+++ b/skforecast/recursive/_forecaster_recursive_multiseries.py
@@ -1679,6 +1679,8 @@ class ForecasterRecursiveMultiSeries(ForecasterBase):
                         window_size        = self.window_size,
                         exog               = exog,
                         dropna_last_window = self.dropna_from_series,
+                        estimator          = self.estimator,
+                        differentiation    = self.differentiation,
                         externally_fitted  = False
                     )
         series_train, _, levels_last_window, exog_train, exog_test, _ = next(data_fold)

--- a/skforecast/utils/tests/tests_utils/test_estimator_has_native_nan_support.py
+++ b/skforecast/utils/tests/tests_utils/test_estimator_has_native_nan_support.py
@@ -1,0 +1,78 @@
+# Unit test estimator_has_native_nan_support
+# ==============================================================================
+import pytest
+from sklearn.ensemble import (
+    HistGradientBoostingClassifier,
+    HistGradientBoostingRegressor,
+    RandomForestRegressor,
+)
+from sklearn.linear_model import LinearRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from skforecast.utils import estimator_has_native_nan_support
+
+
+def _fake_estimator(module: str, name: str):
+    """Build a minimal object whose type reports the given module/name."""
+    cls = type(name, (), {})
+    cls.__module__ = module
+    return cls()
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        _fake_estimator('lightgbm.sklearn', 'LGBMRegressor'),
+        _fake_estimator('xgboost.sklearn', 'XGBRegressor'),
+        _fake_estimator('catboost.core', 'CatBoostRegressor'),
+        HistGradientBoostingRegressor(),
+        HistGradientBoostingClassifier(),
+        Pipeline([
+            ("scaler", StandardScaler()),
+            ("model", _fake_estimator('lightgbm.sklearn', 'LGBMRegressor')),
+        ]),
+        Pipeline([
+            ("scaler", StandardScaler()),
+            ("model", HistGradientBoostingRegressor()),
+        ]),
+    ],
+    ids=[
+        'lightgbm',
+        'xgboost',
+        'catboost',
+        'HistGradientBoostingRegressor',
+        'HistGradientBoostingClassifier',
+        'Pipeline-lightgbm',
+        'Pipeline-HistGradientBoostingRegressor',
+    ],
+)
+def test_estimator_has_native_nan_support_true(estimator):
+    """
+    NaN-tolerant estimator families return True, including Pipeline last steps.
+    """
+    assert estimator_has_native_nan_support(estimator) is True
+
+
+@pytest.mark.parametrize(
+    "estimator",
+    [
+        LinearRegression(),
+        RandomForestRegressor(n_estimators=2, random_state=123),
+        Pipeline([
+            ("scaler", StandardScaler()),
+            ("model", LinearRegression()),
+        ]),
+        _fake_estimator('sklearn.ensemble._forest', 'RandomForestRegressor'),
+    ],
+    ids=[
+        'LinearRegression',
+        'RandomForestRegressor',
+        'Pipeline-LinearRegression',
+        'fake-RandomForestRegressor',
+    ],
+)
+def test_estimator_has_native_nan_support_false(estimator):
+    """
+    Estimators without native NaN support return False.
+    """
+    assert estimator_has_native_nan_support(estimator) is False

--- a/skforecast/utils/utils.py
+++ b/skforecast/utils/utils.py
@@ -630,6 +630,46 @@ def configure_estimator_categorical_features(
     return fit_kwargs
 
 
+def estimator_has_native_nan_support(estimator: object) -> bool:
+    """
+    Check whether an estimator natively supports NaN values in its input
+    features.
+
+    Uses the same module-based family detection as
+    `configure_estimator_categorical_features`. Recognized families are
+    lightgbm, catboost, xgboost, and sklearn's HistGradientBoostingRegressor /
+    HistGradientBoostingClassifier. If `estimator` is a Pipeline, the last step
+    is inspected.
+
+    Parameters
+    ----------
+    estimator : object
+        Estimator object. If the estimator is a Pipeline, the last step is used.
+
+    Returns
+    -------
+    has_native_nan_support : bool
+        `True` if the estimator natively supports NaN inputs, otherwise `False`.
+
+    """
+
+    if isinstance(estimator, Pipeline):
+        estimator = estimator[-1]
+
+    estimator_name = type(estimator).__name__
+    module = type(estimator).__module__.split('.')[0]
+
+    if module in ('lightgbm', 'catboost', 'xgboost'):
+        return True
+
+    if module == 'sklearn' and estimator_name in (
+        'HistGradientBoostingRegressor', 'HistGradientBoostingClassifier'
+    ):
+        return True
+
+    return False
+
+
 def cast_catboost_categorical_columns(
     X: np.ndarray,
     fit_kwargs: dict[str, object],


### PR DESCRIPTION
## Summary
- Implements the maintainer-preferred design for #1196: when \`dropna_last_window=True\`, keep levels whose last window contains NaNs **only if** the estimator natively supports NaN inputs and the forecaster has **no differentiation**.
- Adds \`estimator_has_native_nan_support\` in \`skforecast.utils\`, reusing the module-based family detection from \`configure_estimator_categorical_features\` (lightgbm / catboost / xgboost / sklearn HistGradientBoosting) and unwrapping \`Pipeline\` first.
- Does **not** add a new public parameter. Removes the earlier \`min_non_nan_last_window\` approach.

Closes #1196

## Behavior
- \`dropna_last_window=False\`: unchanged
- \`dropna_last_window=True\` + NaN-tolerant estimator + \`differentiation is None\`: keep levels with NaNs in the last window
- \`dropna_last_window=True\` + non-tolerant estimator **or** differentiation set: \`dropna(how=\"any\")\` (current behavior)
- No extra warning (existing \`MissingValuesWarning\` in \`check_predict_input\` covers this)

## Test plan
- [x] Helper tests for lightgbm/catboost/xgboost/HistGradientBoosting (+ Pipeline unwrap)
- [x] Fold extraction: NaN-tolerant keeps level
- [x] Fold extraction: non-tolerant drops level
- [x] Fold extraction: differentiation forces drop even for NaN-tolerant estimators
- [x] Existing \`test_extract_data_folds_multiseries\` suite still passes