### PR TITLE
Add Bayesian foundation model support and update documentation

### DIFF
--- a/skforecast/model_selection/_search.py
+++ b/skforecast/model_selection/_search.py
@@ -2144,16 +2144,14 @@ def bayesian_search_foundation(
 
         - All models: `context_length` (int or categorical list).
         - Amazon Chronos-2: `cross_learning` (bool).
-        - Google TimesFM 2.5: `max_horizon` (int).
-        - TabICLv2, Prior Labs TabPFN-TS: `point_estimate` (str),
+        - Soda-INRIA TabICL, Prior Labs TabPFN-TS: `point_estimate` (str),
         `temporal_features` (list).
-        - Prior Labs TabPFN-TS: `mode` (str).
         - Synthefy Nori: `point_estimate` (str), `add_calendar_features`
         (bool), `n_fourier_terms` (int).
 
-        Note: changing `model_id`, device arguments, or `torch_dtype` forces a 
-        full model reload and is expensive. On Google TimesFM 2.5 and 
-        Salesforce Moirai-2, changing `context_length` also forces a reload.
+        Note: changing `model_id`, device arguments, or `torch_dtype` forces a
+        full model reload and is expensive. Changing `context_length` also
+        forces a reload on TimesFM 2.5, Moirai-2, TabICL and TabPFN-TS.
     metric : str, Callable, list
         Metric used to quantify the goodness of fit of the model.
 

--- a/skills/complete-api-reference/SKILL.md
+++ b/skills/complete-api-reference/SKILL.md
@@ -50,9 +50,11 @@ the complete reference, including:
 - `backtesting_forecaster` — backtest single-series forecasters
 - `backtesting_forecaster_multiseries` — backtest multi-series forecasters
 - `backtesting_stats` — backtest statistical models
+- `backtesting_foundation` — backtest `ForecasterFoundation` (zero-shot)
 - `grid_search_forecaster` / `grid_search_forecaster_multiseries` / `grid_search_stats`
 - `random_search_forecaster` / `random_search_forecaster_multiseries` / `random_search_stats`
 - `bayesian_search_forecaster` / `bayesian_search_forecaster_multiseries`
+- `bayesian_search_foundation` — tune `ForecasterFoundation` inference-time parameters
 - `grid_search_equivalent_date` — tune `ForecasterEquivalentDate` baselines
 - `TimeSeriesFold` — multi-step cross-validation
 - `OneStepAheadFold` — fast one-step cross-validation

--- a/skills/complete-api-reference/references/method-signatures.md
+++ b/skills/complete-api-reference/references/method-signatures.md
@@ -487,6 +487,20 @@ backtesting_stats(
     show_progress=True,                 # bool
     suppress_warnings=False             # bool
 ) -> tuple[pd.DataFrame, pd.DataFrame]
+
+backtesting_foundation(
+    forecaster,                         # ForecasterFoundation
+    series,                             # pd.Series | pd.DataFrame | dict
+    cv,                                 # TimeSeriesFold (refit / fixed_train_size overridden internally)
+    metric,                             # str | Callable | list[str | Callable]
+    levels=None,                        # str | list[str] | None
+    add_aggregated_metric=True,         # bool
+    exog=None,                          # pd.Series | pd.DataFrame | dict | None
+    quantiles=None,                     # list[float] | None, native model quantiles
+    verbose=False,                      # bool
+    show_progress=True,                 # bool
+    suppress_warnings=False             # bool
+) -> tuple[pd.DataFrame, pd.DataFrame]
 ```
 
 ## Hyperparameter Search Functions
@@ -659,6 +673,30 @@ grid_search_equivalent_date(
     suppress_warnings=False, # bool
     output_file=None         # str | None
 ) -> pd.DataFrame
+```
+
+### Foundation Models
+
+```python
+bayesian_search_foundation(
+    forecaster,              # ForecasterFoundation
+    series,                  # pd.Series | pd.DataFrame | dict
+    cv,                      # TimeSeriesFold (OneStepAheadFold raises TypeError)
+    search_space,            # Callable, keys validated against adapter.get_params(); no 'lags'
+    metric,                  # str | Callable | list[str | Callable]
+    aggregate_metric=None,   # str | list[str] | None
+    levels=None,             # str | list[str] | None
+    exog=None,               # pd.Series | pd.DataFrame | dict | None
+    n_trials=20,             # int
+    random_state=123,        # int
+    return_best=True,        # bool
+    verbose=False,           # bool
+    show_progress=True,      # bool
+    suppress_warnings=False, # bool
+    output_file=None,        # str | None, optuna log
+    kwargs_create_study=None,     # dict | None
+    kwargs_study_optimize=None    # dict | None
+) -> tuple[pd.DataFrame, object]
 ```
 
 ## Forecaster Methods: predict_quantiles()

--- a/skills/foundation-forecasting/SKILL.md
+++ b/skills/foundation-forecasting/SKILL.md
@@ -5,8 +5,9 @@ description: >
   (Amazon Chronos-2, Google TimesFM 2.5, Salesforce Moirai-2, Soda-INRIA TabICL,
   Prior Labs TabPFN-TS, The Forecasting Company T0, EDF Lab TS-ICL, Synthefy Nori) via ForecasterFoundation and
   FoundationModel. Covers single and multi-series
-  workflows, exogenous variables, prediction intervals / quantiles, and
-  backtesting. Use when the user wants forecasts without task-specific
+  workflows, exogenous variables, prediction intervals / quantiles,
+  backtesting, and inference-time parameter search (context_length tuning).
+  Use when the user wants forecasts without task-specific
   training, cold-start baselines, or pre-trained generalist models.
 ---
 
@@ -33,9 +34,11 @@ Scan before writing code. Each row lists a rule, the symptom when it is broken, 
 | Rule | Symptom | Recovery |
 |------|---------|----------|
 | `fit()` stores context only; it never trains the model | Expecting training to happen or weights to update | Treat the model as pre-trained; evaluate with `backtesting_foundation` |
+| `cv.refit` and `cv.fixed_train_size` are overridden by `backtesting_foundation` | `IgnoredArgumentWarning` when `refit=True` or `fixed_train_size=False` | Leave them at their defaults; the context window expands per fold either way |
 | Only Chronos-2, TabICL, TabPFN-TS, T0, Nori, and TS-ICL use `exog`; TimesFM 2.5 and Moirai-2 ignore it | `exog` silently dropped, no error raised | Pick an exog-capable adapter when covariates matter |
 | TimesFM 2.5 and Moirai-2 restrict quantiles to `[0.1, 0.2, ..., 0.9]` | Requested quantile rejected or unsupported | Request only supported quantiles, or use an adapter allowing any quantile in (0, 1) |
 | Each backend library must be installed separately | `ModuleNotFoundError` / `ImportError` on first use | `pip install` the matching backend (see Installation) |
+| Tuning uses `bayesian_search_foundation`, never `bayesian_search_forecaster*` | `TypeError` on the forecaster type or on `OneStepAheadFold` | Call `bayesian_search_foundation` with a `TimeSeriesFold` |
 
 ## Installation
 
@@ -156,7 +159,7 @@ The adapter is resolved automatically from the `model_id` prefix — no need to 
 
 ## Backtesting
 
-Use the dedicated `backtesting_foundation` function — it is the only backtester that accepts a `ForecasterFoundation`. Refit is always disabled internally (the loaded model weights are preserved across folds) and probabilistic output is requested via `quantiles`, not `interval`.
+Use the dedicated `backtesting_foundation` function — it is the only backtester that accepts a `ForecasterFoundation`. Internally `cv` is deep-copied and forced to `refit=True`, `fixed_train_size=False`, so the context window expands with each fold up to `context_length`; no weights are ever trained. Probabilistic output is requested via `quantiles`, not `interval`.
 
 ```python
 from skforecast.model_selection import backtesting_foundation, TimeSeriesFold
@@ -164,7 +167,7 @@ from skforecast.model_selection import backtesting_foundation, TimeSeriesFold
 cv = TimeSeriesFold(
     steps=24,
     initial_train_size=len(series) - 200,
-    refit=False,      # Refit is always disabled for foundation forecasters
+    refit=False,      # Overridden internally; passing True emits IgnoredArgumentWarning
 )
 
 metric, predictions = backtesting_foundation(
@@ -175,6 +178,38 @@ metric, predictions = backtesting_foundation(
     quantiles=[0.1, 0.5, 0.9],   # Native model quantiles; no bootstrapping
 )
 ```
+
+## Tuning Inference-Time Parameters
+
+No weights are trained, so tuning means choosing how the pre-trained model is
+queried. `context_length` is the highest-impact parameter. Use
+`bayesian_search_foundation` (`TimeSeriesFold` only, no `lags`, no `n_jobs`):
+
+```python
+from skforecast.model_selection import bayesian_search_foundation, TimeSeriesFold
+
+def search_space(trial):
+    return {
+        'context_length': trial.suggest_categorical('context_length', [512, 1024, 2048, 4096]),
+    }
+
+results, study = bayesian_search_foundation(
+    forecaster=forecaster,
+    series=series,
+    cv=cv,
+    search_space=search_space,
+    metric='mean_absolute_error',
+    n_trials=30,
+    return_best=True,
+)
+```
+
+Keys are validated against the adapter's `get_params()`. Search
+`context_length` and the adapter's quality-relevant parameters; runtime
+settings (`device`, `torch_dtype`, `mode`, `show_progress`, `max_horizon`) are
+accepted but cannot improve accuracy, and several parameters force an expensive
+model reload per trial. Per-adapter matrix:
+[references/adapter-parameters.md](references/adapter-parameters.md).
 
 ## Override the Stored Context
 
@@ -201,3 +236,4 @@ automatically to the last `context_length` observations.
 4. **Requesting unsupported quantiles**: TimesFM 2.5 and Moirai-2 are restricted to the nine deciles `0.1 … 0.9` ; TS-ICL is restricted to a 0.01 grid in `[0.01, 0.99]`.
 5. **Large model downloads**: first call can be slow; consider using smaller variants (`*-small`) for experimentation.
 6. **Forgetting to install the backend**: each foundation model requires its own library (`chronos-forecasting`, `timesfm`, `uni2ts`, `tabicl`, `tabpfn-time-series`, `tfc-t0`, `synthefy-nori`, `tsicl`). Install only the one(s) you need.
+7. **Tuning a parameter that forces a model reload**: `model_id` and device/dtype arguments reload the model on every trial, and `context_length` does the same on TimesFM 2.5, Moirai-2, TabICL and TabPFN-TS.

--- a/skills/foundation-forecasting/references/adapter-parameters.md
+++ b/skills/foundation-forecasting/references/adapter-parameters.md
@@ -141,22 +141,31 @@ Covariates must be numeric; encode categoricals as numbers before passing them.
 
 Nori frames forecasting as tabular in-context regression rather than a native sequence model: each series is featurized (running index, calendar features, Fourier terms, and known-future covariates) before being handed to `NoriRegressor`. Covariates must be numeric; encode categoricals as numbers before passing them.
 
-## TSICLAdapter — EDF Lab TS-ICL
+## Tunable Parameters and Model Reload Cost
 
-- **`model_id` prefix**: `taharnbl/TS-ICL`. Used only for adapter resolution; the checkpoint is always downloaded from the `taharnbl/TS-ICL` Hugging Face repository, controlled by `checkpoint_version`.
-- **`allow_exog`**: `True` (past and future covariates, mirroring `ChronosAdapter`'s `past_covariates`/`future_covariates` format)
-- **Quantiles**: subset of a 0.01 grid in `[0.01, 0.99]` (e.g. `0.05`, `0.5`, `0.37`); other levels raise a `ValueError`
+The parameters that can be changed after construction (via `set_params`, and therefore searched with `bayesian_search_foundation`) are exactly the keys returned by each adapter's `get_params()`. Any other key raises `ValueError`. Note that `model` / `pipeline` / `module` are constructor-only and are **not** settable.
 
-| Parameter              | Type | Default            | Description                                                                |
-|------------------------|------|--------------------|------------------------------------------------------------------------------|
-| `model_id`             | str  | —                  | Model ID (e.g. `taharnbl/TS-ICL`). Used only for adapter resolution.        |
-| `model`                | obj  | `None`             | Pre-instantiated `TSICL` model. If `None`, created lazily on first `predict`.|
-| `checkpoint_version`   | str  | `'tsicl-v1.ckpt'`  | Checkpoint filename downloaded from the `taharnbl/TS-ICL` Hugging Face repo. |
-| `context_length`       | int  | `4096`             | Max historical observations kept as context.                                |
-| `device`               | str  | `'auto'`           | Device placement: `'auto'` (CUDA > MPS > CPU), `'cuda'`, `'mps'`, `'cpu'`. Verified empirically: the installed `tsicl` version currently falls back to CPU internally whenever CUDA is unavailable, regardless of the requested device, so `'mps'` has no effect on Apple Silicon. |
-| `allow_auto_download`  | bool | `True`             | Whether to allow automatic download of the checkpoint from Hugging Face Hub. |
+Being accepted is not the same as being worth searching. Most adapters expose runtime settings that cannot improve accuracy: `device`, `device_map`, `torch_dtype`, `mode` (local vs cloud inference), `show_progress`, `allow_auto_download`, and `max_horizon` (a ceiling only, the TimesFM model is recompiled for the requested `steps` regardless). Keep these fixed. `model_id` (and `checkpoint_version` on TS-ICL) does change accuracy, but it selects a different pre-trained model, so compare those with separate searches instead of mixing them into one search space.
 
-Covariates must be numeric; encode categoricals as numbers before passing them.
+| Adapter | Accepted by `set_params` (`get_params()` keys) | Worth searching | Changing these forces a model reload |
+|---------|-----------------------------------------------|-----------------|--------------------------------------|
+| ChronosAdapter | `model_id`, `cross_learning`, `context_length`, `device_map`, `torch_dtype`, `predict_kwargs` | `context_length`, `cross_learning`, (`predict_kwargs`) | `model_id`, `device_map`, `torch_dtype` |
+| TimesFMAdapter | `model_id`, `context_length`, `max_horizon`, `forecast_config_kwargs` | `context_length`, (`forecast_config_kwargs`) | **all of them** |
+| MoiraiAdapter | `model_id`, `context_length`, `device` | `context_length` | **all of them** |
+| TabICLAdapter | `model_id`, `context_length`, `point_estimate`, `tabicl_config`, `temporal_features`, `show_progress` | `context_length`, `point_estimate`, `temporal_features`, (`tabicl_config`) | all except `show_progress` |
+| TabPFNAdapter | `model_id`, `context_length`, `mode`, `point_estimate`, `tabpfn_model_config`, `temporal_features`, `show_progress` | `context_length`, `point_estimate`, `temporal_features`, (`tabpfn_model_config`) | all except `show_progress` |
+| T0Adapter | `model_id`, `context_length`, `device_map`, `torch_dtype` | `context_length` | `model_id`, `device_map`, `torch_dtype` |
+| TSICLAdapter | `model_id`, `checkpoint_version`, `context_length`, `device`, `allow_auto_download` | `context_length` | `checkpoint_version`, `allow_auto_download` (`device` only clears the cached resolved device) |
+| NoriAdapter | `model_id`, `context_length`, `point_estimate`, `add_calendar_features`, `n_fourier_terms`, `nori_config` | `context_length`, `point_estimate`, `add_calendar_features`, `n_fourier_terms`, (`nori_config`) | `model_id`, `nori_config` |
+
+Parameters in parentheses are backend passthrough dicts: they can hold quality-relevant settings but are awkward to search, so treat them as advanced.
+
+Two consequences that matter when tuning:
+
+- **`context_length` is not uniformly cheap.** It reloads the model on TimesFM 2.5, Moirai-2, TabICL and TabPFN-TS; it is free on Chronos-2, T0, TS-ICL and Nori.
+- **Reset on presence vs on change.** `TabICLAdapter`, `TabPFNAdapter` and `NoriAdapter` compare the old and new values first, so re-sampling an identical value costs nothing. `ChronosAdapter`, `TimesFMAdapter`, `MoiraiAdapter`, `T0Adapter` and `TSICLAdapter` reset whenever the key is passed, even if the value is unchanged, so on TimesFM 2.5 and Moirai-2 every single trial that samples `context_length` triggers a reload.
+
+`model_id` forces a reload on every adapter except `TSICLAdapter`, where the checkpoint is selected by `checkpoint_version` instead.
 
 ## Common Behavior
 

--- a/skills/hyperparameter-optimization/SKILL.md
+++ b/skills/hyperparameter-optimization/SKILL.md
@@ -31,6 +31,7 @@ Use hyperparameter search after establishing a baseline forecaster to improve pr
 - **Before**: `autocorrelation-and-lag-selection` (narrow the `lags` search space to a statistically informed candidate set)
 - **Before**: `feature-selection` (run the search on a reduced feature set to make it tractable)
 - **Related**: `baseline-forecasting` (tune `ForecasterEquivalentDate` baselines with `grid_search_equivalent_date`)
+- **Related**: `foundation-forecasting` (tune zero-shot `ForecasterFoundation` inference parameters with `bayesian_search_foundation`)
 - **After**: `prediction-intervals` (add uncertainty quantification once the configuration is fixed)
 
 ## Stop Conditions
@@ -41,6 +42,7 @@ Scan before writing code. Each row lists a rule, the symptom when it is broken, 
 |------|---------|----------|
 | The search refits the forecaster in place with the best params when `return_best=True` (the default) | With `return_best=False`, the forecaster keeps its pre-search params | Rely on the default, or refit with the best params from the results table |
 | Use the `*_multiseries` / `*_stats` search variant matching the forecaster type | Search function raises on the wrong forecaster type | Call e.g. `bayesian_search_forecaster_multiseries` / `grid_search_stats` / `grid_search_equivalent_date` |
+| `ForecasterFoundation` is tuned only with `bayesian_search_foundation` and `TimeSeriesFold` | `TypeError` from the generic search functions, or from passing `OneStepAheadFold` | Call `bayesian_search_foundation` with a `TimeSeriesFold` |
 | Include `lags` in the Bayesian `search_space()` | Suboptimal search; the highest-impact parameter stays fixed | Add `trial.suggest_categorical('lags', [...])` to the search space |
 
 ## Bayesian Search (Recommended)
@@ -208,6 +210,50 @@ results = grid_search_stats(
 )
 ```
 
+## Foundation Model Search
+
+`ForecasterFoundation` is zero-shot: no weights are trained, so only the
+**inference-time** configuration is tuned. The highest-impact parameter is
+`context_length` (how many past observations are fed to the model). Use
+`bayesian_search_foundation`, which evaluates each trial with
+`backtesting_foundation`.
+
+```python
+from skforecast.foundation import FoundationModel, ForecasterFoundation
+from skforecast.model_selection import bayesian_search_foundation, TimeSeriesFold
+
+forecaster = ForecasterFoundation(
+    estimator=FoundationModel(model_id='autogluon/chronos-2-small', device_map='auto')
+)
+
+# TimeSeriesFold only — OneStepAheadFold raises TypeError
+cv = TimeSeriesFold(steps=24, initial_train_size=len(series) - 200, refit=False)
+
+def search_space(trial):
+    return {
+        'context_length': trial.suggest_categorical('context_length', [512, 1024, 2048, 4096]),
+        'cross_learning': trial.suggest_categorical('cross_learning', [True, False]),
+    }
+
+results, study = bayesian_search_foundation(
+    forecaster=forecaster,
+    series=series,
+    cv=cv,
+    search_space=search_space,
+    metric='mean_absolute_error',
+    n_trials=30,
+    return_best=True,
+)
+```
+
+Differences from `bayesian_search_forecaster`: no `lags` in `search_space`, no
+`n_jobs`, `TimeSeriesFold` only, and every `search_space` key must be a valid
+adapter parameter. Search `context_length` and the adapter's quality-relevant
+parameters; device/dtype and other runtime settings are accepted but cannot
+improve accuracy, and several parameters force an expensive model reload per
+trial. Per-adapter tunables and reload matrix: the `foundation-forecasting`
+skill (`references/adapter-parameters.md`).
+
 ## Fast Tuning with OneStepAheadFold
 
 ```python
@@ -236,3 +282,4 @@ results, study = bayesian_search_forecaster(
 2. **Too few trials in Bayesian search**: Start with at least 20-50 trials for meaningful exploration.
 3. **Using TimeSeriesFold for initial tuning**: Use `OneStepAheadFold` first for fast screening, then validate the top candidates with `TimeSeriesFold`.
 4. **Forgetting to include lags in search space**: For Bayesian search, lags can be included in `search_space()` — this is often the most impactful parameter.
+5. **Putting `lags` in a foundation `search_space`**: `bayesian_search_foundation` has no lag concept; any key that is not an adapter parameter raises `ValueError`.

--- a/skills/hyperparameter-optimization/references/search-parameters.md
+++ b/skills/hyperparameter-optimization/references/search-parameters.md
@@ -11,6 +11,7 @@
 | ForecasterRnn | `grid_search_forecaster_multiseries` | `random_search_forecaster_multiseries` | `bayesian_search_forecaster_multiseries` |
 | ForecasterStats | `grid_search_stats` | `random_search_stats` | N/A |
 | ForecasterEquivalentDate | `grid_search_equivalent_date` | N/A | N/A |
+| ForecasterFoundation | N/A | N/A | `bayesian_search_foundation` |
 | ForecasterRecursiveClassifier | `grid_search_forecaster` | `random_search_forecaster` | `bayesian_search_forecaster` |
 
 ## Parameter Comparison Across Search Functions
@@ -72,6 +73,86 @@ Default `aggregate_metric = ['weighted_average', 'average', 'pooling']`
 
 > **Note:** Stats search does NOT support `OneStepAheadFold`, `lags_grid`,
 > or Bayesian search.
+
+### Foundation Function (zero-shot inference-time tuning)
+
+`bayesian_search_foundation` tunes the **inference-time** configuration of a
+`ForecasterFoundation`. Foundation models are zero-shot, so no weights are
+trained; only how the pre-trained model is queried is optimized. Each trial is
+evaluated with `backtesting_foundation`.
+
+| Parameter | `bayesian_search_foundation` |
+|-----------|:---:|
+| `forecaster` | ✓ (must be `ForecasterFoundation`) |
+| `series` | ✓ (`pd.Series`, `pd.DataFrame` or `dict`) |
+| `cv` | **TimeSeriesFold only** |
+| `search_space` | ✓ (Callable) |
+| `metric` | ✓ |
+| `aggregate_metric` | ✓ (default: `['weighted_average', 'average', 'pooling']`) |
+| `levels` | ✓ |
+| `exog` | ✓ |
+| `n_trials` | ✓ (default: 20) |
+| `random_state` | ✓ (default: 123) |
+| `return_best` | ✓ (default: True) |
+| `n_jobs` | — |
+| `verbose` / `show_progress` / `suppress_warnings` | ✓ |
+| `output_file` | ✓ (optuna log, not results TSV) |
+| `kwargs_create_study` / `kwargs_study_optimize` | ✓ (default: None) |
+| **Returns** | `tuple[pd.DataFrame, optuna Study]` |
+
+> **Note:** No `n_jobs`, no `lags` / `lags_grid` (foundation models have no lag
+> concept), no `OneStepAheadFold` (raises `TypeError`), and no grid/random
+> variant. Passing a `ForecasterFoundation` to `bayesian_search_forecaster*`
+> raises `TypeError`.
+
+Every key returned by `search_space` is validated against
+`forecaster.estimator.adapter.get_params()`; an unknown key raises `ValueError`.
+Being accepted is not the same as being worth searching:
+
+| Model | Worth searching |
+|-------|-----------------|
+| All models | `context_length` |
+| Amazon Chronos-2 | `cross_learning` |
+| TabICL, Prior Labs TabPFN-TS | `point_estimate`, `temporal_features` |
+| Synthefy Nori | `point_estimate`, `add_calendar_features`, `n_fourier_terms` |
+| Moirai-2, T0 | `context_length` only |
+
+Do not search `device`, `device_map`, `torch_dtype`, `mode`, `show_progress`,
+`allow_auto_download` or `max_horizon`: they are accepted but cannot improve
+accuracy. `model_id` and `checkpoint_version` do, but they select a different
+pre-trained model — compare those with separate searches.
+
+Cost warning: `model_id` and device/dtype arguments force a full model reload,
+and `context_length` does too on TimesFM 2.5, Moirai-2, TabICL and TabPFN-TS.
+Full matrix: the `foundation-forecasting` skill
+(`references/adapter-parameters.md`).
+
+```python
+from skforecast.foundation import FoundationModel, ForecasterFoundation
+from skforecast.model_selection import bayesian_search_foundation, TimeSeriesFold
+
+forecaster = ForecasterFoundation(
+    estimator=FoundationModel(model_id='autogluon/chronos-2-small', device_map='auto')
+)
+cv = TimeSeriesFold(steps=24, initial_train_size=len(series) - 200, refit=False)
+
+def search_space(trial):
+    return {
+        'context_length': trial.suggest_categorical('context_length', [512, 1024, 2048, 4096]),
+        'cross_learning': trial.suggest_categorical('cross_learning', [True, False]),
+    }
+
+results, study = bayesian_search_foundation(
+    forecaster=forecaster,
+    series=series,
+    cv=cv,
+    search_space=search_space,
+    metric='mean_absolute_error',
+    n_trials=30,
+    return_best=True,
+)
+# results columns: trial_number, levels, params, metric/s, one column per searched param
+```
 
 ### Equivalent Date Function (baseline tuning)
 
@@ -201,6 +282,16 @@ def search_space(trial):
 # Evaluates n_trials=20 trials (default), guided by TPE sampler
 ```
 
+For `bayesian_search_foundation` the same `search_space` contract applies, but
+`lags` must NOT be included and every key must be a valid adapter parameter:
+
+```python
+def search_space(trial):
+    return {
+        'context_length': trial.suggest_categorical('context_length', [512, 2048, 8192]),
+    }
+```
+
 ## Stats Model param_grid
 
 Parameters in `param_grid` for stats models are passed to the model constructor:
@@ -246,6 +337,7 @@ results, study = bayesian_search_forecaster(
 | `random_search_*` | `pd.DataFrame` sorted by metric | — |
 | `bayesian_search_*` | `tuple[pd.DataFrame, optuna Study]` | ✓ |
 | `*_stats` | `pd.DataFrame` sorted by metric | — |
+| `bayesian_search_foundation` | `tuple[pd.DataFrame, optuna Study]`, no `lags` column | ✓ |
 
 When `return_best=True`, the forecaster is automatically updated with the
 best parameters found. The results DataFrame always has rows sorted by

--- a/skills/troubleshooting-common-errors/SKILL.md
+++ b/skills/troubleshooting-common-errors/SKILL.md
@@ -153,6 +153,19 @@ from skforecast.model_selection import grid_search_forecaster_multiseries
 grid_search_forecaster_multiseries(
     forecaster=forecaster_multi, series=series, cv=cv, param_grid=param_grid
 )
+
+# ❌ WRONG: bayesian_search_forecaster with ForecasterFoundation
+bayesian_search_forecaster(forecaster=forecaster_foundation, y=y, cv=cv, search_space=search_space)
+
+# ✅ CORRECT: bayesian_search_foundation (TimeSeriesFold only, no 'lags' in search_space)
+from skforecast.model_selection import bayesian_search_foundation
+bayesian_search_foundation(
+    forecaster=forecaster_foundation, series=series, cv=cv,
+    search_space=lambda trial: {
+        'context_length': trial.suggest_categorical('context_length', [512, 2048])
+    },
+    metric='mean_absolute_error',
+)
 ```
 
 ## Prediction Interval Errors

--- a/tools/ai/llms-base.txt
+++ b/tools/ai/llms-base.txt
@@ -479,7 +479,8 @@ Key points:
 - `fit()` only stores the last `context_length` observations and metadata. It does **not** train the model.
 - The index must have a frequency (`data.asfreq(...)`), same requirement as other skforecast forecasters.
 - `predict(..., context=...)` lets you override the stored context (used internally by backtesting).
-- Use `backtesting_foundation` (not `backtesting_forecaster`) to evaluate a `ForecasterFoundation`. Refit is always disabled internally, model weights are preserved across folds since there is no per-fold training.
+- Use `backtesting_foundation` (not `backtesting_forecaster`) to evaluate a `ForecasterFoundation`. It deep-copies `cv` and forces `refit=True`, `fixed_train_size=False`, so the context window expands with each fold up to `context_length`; no weights are ever trained.
+- Use `bayesian_search_foundation` (not `bayesian_search_forecaster`) to tune inference-time parameters such as `context_length`. Only `TimeSeriesFold` is supported.
 
 ## Feature Selection
 


### PR DESCRIPTION
- Introduced `bayesian_search_foundation` for tuning `ForecasterFoundation` inference-time parameters.
- Updated `SKILL.md` files to include new functions and their usage.
- Enhanced `method-signatures.md` with signatures for new backtesting and search functions.
- Clarified usage instructions in troubleshooting documentation regarding foundation models.