### PR TITLE
Bump version to 0.25.0, deprecate percentiles and update documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,13 +47,13 @@ reuse it for the rest of the session without asking again.
 
 > Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models
 
-This document is for skforecast v0.24.0+. If you are using an older version, check the documentation at skforecast.org.
+This document is for skforecast v0.25.0+. If you are using an older version, check the documentation at skforecast.org.
 
 Skforecast is a Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models. It works with any estimator compatible with the scikit-learn API (LightGBM, XGBoost, CatBoost, Keras, etc.).
 
 ## Quick Info
 
-- Version: 0.24.0
+- Version: 0.25.0
 - License: BSD-3-Clause
 - Python: 3.10, 3.11, 3.12, 3.13, 3.14
 - Repository: https://github.com/skforecast/skforecast
@@ -715,5 +715,5 @@ show_datasets_info()
 ## Citation
 
 ```
-Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.25.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,13 +47,13 @@ reuse it for the rest of the session without asking again.
 
 > Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models
 
-This document is for skforecast v0.24.0+. If you are using an older version, check the documentation at skforecast.org.
+This document is for skforecast v0.25.0+. If you are using an older version, check the documentation at skforecast.org.
 
 Skforecast is a Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models. It works with any estimator compatible with the scikit-learn API (LightGBM, XGBoost, CatBoost, Keras, etc.).
 
 ## Quick Info
 
-- Version: 0.24.0
+- Version: 0.25.0
 - License: BSD-3-Clause
 - Python: 3.10, 3.11, 3.12, 3.13, 3.14
 - Repository: https://github.com/skforecast/skforecast
@@ -715,5 +715,5 @@ show_datasets_info()
 ## Citation
 
 ```
-Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.25.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
 ```

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,5 +26,5 @@ keywords:
   - python
 doi: 10.5281/zenodo.8382787
 license: bsd-3-clause
-version: 0.24.0
+version: 0.25.0
 date-released: '2026-08-24'

--- a/README.md
+++ b/README.md
@@ -203,12 +203,12 @@ If you use skforecast for a scientific publication, we would appreciate citation
 **Zenodo**
 
 ```
-Amat Rodrigo, Joaquin, & Escobar Ortiz, Javier. (2026). skforecast (v0.24.0). Zenodo. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, Joaquin, & Escobar Ortiz, Javier. (2026). skforecast (v0.25.0). Zenodo. https://doi.org/10.5281/zenodo.8382787
 ```
 
 **APA**:
 ```
-Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.25.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
 ```
 
 **BibTeX**:
@@ -216,7 +216,7 @@ Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Compu
 @software{skforecast,
   author  = {Amat Rodrigo, Joaquin and Escobar Ortiz, Javier},
   title   = {skforecast},
-  version = {0.24.0},
+  version = {0.25.0},
   month   = {8},
   year    = {2026},
   license = {BSD-3-Clause},

--- a/docs/README.md
+++ b/docs/README.md
@@ -142,12 +142,12 @@ If you use skforecast for a scientific publication, we would appreciate citation
 **Zenodo**
 
 ```
-Amat Rodrigo, Joaquin, & Escobar Ortiz, Javier. (2026). skforecast (v0.24.0). Zenodo. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, Joaquin, & Escobar Ortiz, Javier. (2026). skforecast (v0.25.0). Zenodo. https://doi.org/10.5281/zenodo.8382787
 ```
 
 **APA**:
 ```
-Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.25.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
 ```
 
 **BibTeX**:
@@ -155,7 +155,7 @@ Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Compu
 @software{skforecast,
   author  = {Amat Rodrigo, Joaquin and Escobar Ortiz, Javier},
   title   = {skforecast},
-  version = {0.24.0},
+  version = {0.25.0},
   month   = {8},
   year    = {2026},
   license = {BSD-3-Clause},

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6,13 +6,13 @@
 
 > Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models
 
-This document is for skforecast v0.24.0+. If you are using an older version, check the documentation at skforecast.org.
+This document is for skforecast v0.25.0+. If you are using an older version, check the documentation at skforecast.org.
 
 Skforecast is a Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models. It works with any estimator compatible with the scikit-learn API (LightGBM, XGBoost, CatBoost, Keras, etc.).
 
 ## Quick Info
 
-- Version: 0.24.0
+- Version: 0.25.0
 - License: BSD-3-Clause
 - Python: 3.10, 3.11, 3.12, 3.13, 3.14
 - Repository: https://github.com/skforecast/skforecast
@@ -674,7 +674,7 @@ show_datasets_info()
 ## Citation
 
 ```
-Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.25.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
 ```
 
 ================================================================================

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Skforecast
 
-> Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models. Works with any scikit-learn compatible estimator (LightGBM, XGBoost, CatBoost, Keras, etc.). Version 0.24.0+. Python 3.10-3.14. BSD-3-Clause.
+> Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models. Works with any scikit-learn compatible estimator (LightGBM, XGBoost, CatBoost, Keras, etc.). Version 0.25.0+. Python 3.10-3.14. BSD-3-Clause.
 
 - [Documentation](https://skforecast.org/latest/): Full documentation site
 - [PyPI](https://pypi.org/project/skforecast/): pip install skforecast

--- a/docs/more/about-skforecast.md
+++ b/docs/more/about-skforecast.md
@@ -81,12 +81,12 @@ If you use skforecast for a scientific publication, we would appreciate citation
 **Zenodo**
 
 ```
-Amat Rodrigo, Joaquin, & Escobar Ortiz, Javier. (2026). skforecast (v0.24.0). Zenodo. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, Joaquin, & Escobar Ortiz, Javier. (2026). skforecast (v0.25.0). Zenodo. https://doi.org/10.5281/zenodo.8382787
 ```
 
 **APA**:
 ```
-Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.25.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
 ```
 
 **BibTeX**:
@@ -94,7 +94,7 @@ Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Compu
 @software{skforecast,
   author  = {Amat Rodrigo, Joaquin and Escobar Ortiz, Javier},
   title   = {skforecast},
-  version = {0.24.0},
+  version = {0.25.0},
   month   = {8},
   year    = {2026},
   license = {BSD-3-Clause},

--- a/docs/quick-start/ai-assisted-forecasting.md
+++ b/docs/quick-start/ai-assisted-forecasting.md
@@ -95,5 +95,5 @@ The context files are **auto-generated** from maintained source files (`tools/ai
 
 1. **Always provide the context URL** — Without it, LLMs may hallucinate methods that don't exist or use outdated API names (e.g., `ForecasterAutoreg` instead of `ForecasterRecursive`).
 2. **Be specific about your forecaster** — Mention which forecaster you're using. Parameter names and defaults differ across forecasters.
-3. **Mention the version** — Say "skforecast 0.24.0" so the LLM doesn't mix advice from older versions.
+3. **Mention the version** — Say "skforecast 0.25.0" so the LLM doesn't mix advice from older versions.
 4. **Validate the output** — AI-generated code is a starting point. Use backtesting or an appropriate holdout evaluation to verify model performance.

--- a/docs/quick-start/how-to-install.md
+++ b/docs/quick-start/how-to-install.md
@@ -18,7 +18,7 @@ pip install skforecast
 Specific version:
 
 ```bash
-pip install skforecast==0.24.0
+pip install skforecast==0.25.0
 ```
 
 Latest (unstable):

--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -10,6 +10,29 @@ All significant changes to this project are documented in this release file.
 | <span class="badge text-bg-fix">Fix</span>                 | Bug fix                               |
 
 
+## 0.25.0 <small>In development</small> { id="0.25.0" }
+
+The main changes in this release are:
+
++ <span class="badge text-bg-api-change">API Change</span> Removed support for percentiles in the `interval` argument of the `predict_interval` method of the Forecasters and of the backtesting functions. Deprecated since 0.23.0, `interval` must now be expressed as quantiles in the 0-1 range (e.g. `interval=[0.05, 0.95]`). Passing percentiles such as `interval=[5, 95]` no longer emits a `FutureWarning` and raises a `ValueError` instead.
+
++ <span class="badge text-bg-api-change">API Change</span> Removed support for percentiles in the `level` argument of the `predict_interval` method of the statistical estimators (<code>[Arima]</code>, <code>[Arar]</code>, <code>[Ets]</code>). Deprecated since 0.23.0, `level` must now be expressed as coverage proportions in the (0, 1] range (e.g. `level=[0.8, 0.95]`). Passing percentiles such as `level=[80, 95]` no longer emits a `FutureWarning` and raises a `ValueError` instead.
+
+
+**Added**
+
+
+**Changed**
+
++ Removed support for percentiles in the `interval` argument of the `predict_interval` method of the Forecasters and of the backtesting functions. Deprecated since 0.23.0, `interval` must now be expressed as quantiles in the 0-1 range (e.g. `interval=[0.05, 0.95]`). Passing percentiles such as `interval=[5, 95]` no longer emits a `FutureWarning` and raises a `ValueError` instead.
+
++ Removed support for percentiles in the `level` argument of the `predict_interval` method of the statistical estimators (<code>[Arima]</code>, <code>[Arar]</code>, <code>[Ets]</code>). Deprecated since 0.23.0, `level` must now be expressed as coverage proportions in the (0, 1] range (e.g. `level=[0.8, 0.95]`). Passing percentiles such as `level=[80, 95]` no longer emits a `FutureWarning` and raises a `ValueError` instead.
+
+
+**Fixed**
+
+
+
 ## 0.24.0 <small>Aug 24, 2026</small> { id="0.24.0" }
 
 The main changes in this release are:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6,13 +6,13 @@
 
 > Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models
 
-This document is for skforecast v0.24.0+. If you are using an older version, check the documentation at skforecast.org.
+This document is for skforecast v0.25.0+. If you are using an older version, check the documentation at skforecast.org.
 
 Skforecast is a Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models. It works with any estimator compatible with the scikit-learn API (LightGBM, XGBoost, CatBoost, Keras, etc.).
 
 ## Quick Info
 
-- Version: 0.24.0
+- Version: 0.25.0
 - License: BSD-3-Clause
 - Python: 3.10, 3.11, 3.12, 3.13, 3.14
 - Repository: https://github.com/skforecast/skforecast
@@ -674,7 +674,7 @@ show_datasets_info()
 ## Citation
 
 ```
-Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.25.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
 ```
 
 ================================================================================

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Skforecast
 
-> Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models. Works with any scikit-learn compatible estimator (LightGBM, XGBoost, CatBoost, Keras, etc.). Version 0.24.0+. Python 3.10-3.14. BSD-3-Clause.
+> Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models. Works with any scikit-learn compatible estimator (LightGBM, XGBoost, CatBoost, Keras, etc.). Version 0.25.0+. Python 3.10-3.14. BSD-3-Clause.
 
 - [Documentation](https://skforecast.org/latest/): Full documentation site
 - [PyPI](https://pypi.org/project/skforecast/): pip install skforecast

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skforecast"
-version = "0.24.0"
+version = "0.25.0"
 description = "Skforecast is a Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models. It works with any estimator compatible with the scikit-learn API, including popular options like LightGBM, XGBoost, CatBoost, Keras, and many others."
 readme = "README.md"
 authors = [

--- a/skforecast/__init__.py
+++ b/skforecast/__init__.py
@@ -12,4 +12,4 @@ Examples:  https://skforecast.org/latest/examples/examples_english.html
 """
 
 name = "skforecast"
-__version__ = "0.24.0"
+__version__ = "0.25.0"

--- a/skforecast/deep_learning/_forecaster_rnn.py
+++ b/skforecast/deep_learning/_forecaster_rnn.py
@@ -26,7 +26,6 @@ from ..exceptions import DataTransformationWarning, ResidualsUsageWarning
 from ..utils import (
     check_exog,
     check_interval,
-    _normalize_interval_scale,
     check_predict_input,
     check_residuals_input,
     check_select_fit_kwargs,
@@ -48,7 +47,7 @@ from ..utils import (
 )
 from ..preprocessing import QuantileBinner
 
-# TODO: Review in skforecast 0.23.0
+# TODO: Review in skforecast 0.26.0
 try:
     import keras
 except ImportError as e:
@@ -1827,7 +1826,7 @@ class ForecasterRnn(ForecasterBase):
 
             **Changed in version 0.23.0:** `interval` is now expressed as
             quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
+            is not longer supported and will raise a `ValueError`.
         use_in_sample_residuals : bool, default True
             If `True`, residuals from the training data are used as proxy of
             prediction error to create predictions. 
@@ -1864,7 +1863,6 @@ class ForecasterRnn(ForecasterBase):
         if method == "conformal":
 
             if isinstance(interval, (list, tuple)):
-                interval = _normalize_interval_scale(interval)
                 check_interval(interval=interval, ensure_symmetric_intervals=True)
                 nominal_coverage = interval[1] - interval[0]
             else:

--- a/skforecast/direct/_forecaster_direct.py
+++ b/skforecast/direct/_forecaster_direct.py
@@ -40,7 +40,6 @@ from ..utils import (
     check_predict_input,
     check_residuals_input,
     check_interval,
-    _normalize_interval_scale,
     input_to_frame,
     exog_to_direct_numpy,
     expand_index,
@@ -2761,7 +2760,7 @@ class ForecasterDirect(ForecasterBase):
 
             **Changed in version 0.23.0:** `interval` is now expressed as
             quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
+            is not longer supported and will raise a `ValueError`.
         n_boot : int, default 250
             Number of bootstrapping iterations to perform when estimating prediction
             intervals.
@@ -2804,7 +2803,6 @@ class ForecasterDirect(ForecasterBase):
         if method == "bootstrapping":
             
             if isinstance(interval, (list, tuple)):
-                interval = _normalize_interval_scale(interval)
                 check_interval(interval=interval, ensure_symmetric_intervals=False)
                 interval = np.array(interval)
             else:
@@ -2837,7 +2835,6 @@ class ForecasterDirect(ForecasterBase):
         elif method == 'conformal':
 
             if isinstance(interval, (list, tuple)):
-                interval = _normalize_interval_scale(interval)
                 check_interval(interval=interval, ensure_symmetric_intervals=True)
                 nominal_coverage = interval[1] - interval[0]
             else:

--- a/skforecast/direct/_forecaster_direct_multivariate.py
+++ b/skforecast/direct/_forecaster_direct_multivariate.py
@@ -43,7 +43,6 @@ from ..utils import (
     check_predict_input,
     check_residuals_input,
     check_interval,
-    _normalize_interval_scale,
     check_extract_values_and_index,
     input_to_frame,
     exog_to_direct_numpy,
@@ -2949,7 +2948,7 @@ class ForecasterDirectMultiVariate(ForecasterBase):
 
             **Changed in version 0.23.0:** `interval` is now expressed as
             quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
+            is not longer supported and will raise a `ValueError`.
         n_boot : int, default 250
             Number of bootstrapping iterations to perform when estimating prediction
             intervals.
@@ -2992,7 +2991,6 @@ class ForecasterDirectMultiVariate(ForecasterBase):
         if method == "bootstrapping":
             
             if isinstance(interval, (list, tuple)):
-                interval = _normalize_interval_scale(interval)
                 check_interval(interval=interval, ensure_symmetric_intervals=False)
                 interval = np.array(interval)
             else:
@@ -3026,7 +3024,6 @@ class ForecasterDirectMultiVariate(ForecasterBase):
         elif method == 'conformal':
 
             if isinstance(interval, (list, tuple)):
-                interval = _normalize_interval_scale(interval)
                 check_interval(interval=interval, ensure_symmetric_intervals=True)
                 nominal_coverage = interval[1] - interval[0]
             else:

--- a/skforecast/direct/tests/tests_forecaster_direct/test_predict_interval.py
+++ b/skforecast/direct/tests/tests_forecaster_direct/test_predict_interval.py
@@ -31,29 +31,6 @@ def test_check_interval_ValueError_when_method_is_not_valid_method():
         forecaster.predict_interval(steps=1, method=method)
 
 
-# TODO: Remove in skforecast 0.25.0 when percentile support is removed.
-@pytest.mark.parametrize("method", 
-                         ['bootstrapping', 'conformal'], 
-                         ids = lambda value: f'method: {value}')
-def test_predict_interval_percentile_and_quantile_scales_are_equivalent(method):
-    """
-    Check that the legacy percentile scale [5, 95] produces the same output as
-    the new quantile scale [0.05, 0.95].
-    """
-    forecaster = ForecasterDirect(LinearRegression(), lags=3, steps=3)
-    forecaster.fit(y=pd.Series(np.arange(10)), store_in_sample_residuals=True)
-
-    with pytest.warns(FutureWarning):
-        results_percentile = forecaster.predict_interval(
-            steps=3, method=method, interval=[5, 95], use_binned_residuals=False
-        )
-    results_quantile = forecaster.predict_interval(
-        steps=3, method=method, interval=[0.05, 0.95], use_binned_residuals=False
-    )
-
-    pd.testing.assert_frame_equal(results_percentile, results_quantile)
-
-
 @pytest.mark.parametrize("interval", 
                          [0.90, [0.05, 0.95], (0.05, 0.95)], 
                          ids = lambda value: f'interval: {value}')

--- a/skforecast/direct/tests/tests_forecaster_direct_multivariate/test_predict_interval.py
+++ b/skforecast/direct/tests/tests_forecaster_direct_multivariate/test_predict_interval.py
@@ -191,7 +191,7 @@ def test_predict_interval_output_when_forecaster_is_LinearRegression_steps_is_5_
 
 
 @pytest.mark.parametrize("interval", 
-                         [0.95, (2.5, 97.5)], 
+                         [0.95, (0.025, 0.975)], 
                          ids = lambda value: f'interval: {value}')
 def test_predict_interval_conformal_output_when_estimator_is_LinearRegression(interval):
     """
@@ -225,7 +225,7 @@ def test_predict_interval_conformal_output_when_estimator_is_LinearRegression(in
 
 
 @pytest.mark.parametrize("interval", 
-                         [0.95, (2.5, 97.5)], 
+                         [0.95, (0.025, 0.975)], 
                          ids = lambda value: f'interval: {value}')
 def test_predict_interval_conformal_output_when_binned_residuals(interval):
     """

--- a/skforecast/foundation/_forecaster_foundation.py
+++ b/skforecast/foundation/_forecaster_foundation.py
@@ -17,7 +17,6 @@ from .. import __version__
 from ..exceptions import IgnoredArgumentWarning
 from ._foundation_model import FoundationModel
 from ..utils import (
-    _normalize_interval_scale,
     check_interval,
     get_style_repr_html,
 )
@@ -819,7 +818,7 @@ class ForecasterFoundation:
 
             **Changed in version 0.23.0:** `interval` is now expressed as
             quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
+            is not longer supported and will raise a `ValueError`.
         check_inputs : bool, default True
             If `True`, the `context` and `context_exog` inputs are validated
             and normalized. If `False`, `context` must already be a
@@ -860,7 +859,6 @@ class ForecasterFoundation:
             )
 
         if isinstance(interval, (list, tuple)):
-            interval = _normalize_interval_scale(interval)
             check_interval(interval=interval, ensure_symmetric_intervals=False)
         else:
             check_interval(alpha=interval, alpha_literal='interval')

--- a/skforecast/model_selection/_validation.py
+++ b/skforecast/model_selection/_validation.py
@@ -34,8 +34,7 @@ from ..utils import (
     align_series_and_exog_multiseries,
     manage_warnings,
     deepcopy_forecaster,
-    estimator_has_native_nan_support,
-    _normalize_interval_scale
+    estimator_has_native_nan_support
 )
 from ..foundation._utils import check_preprocess_series_foundation
 
@@ -703,7 +702,7 @@ def backtesting_forecaster(
 
         **Changed in version 0.23.0:** `interval` is now expressed as
         quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-        is deprecated and emits a `FutureWarning`.
+        is not longer supported and will raise a `ValueError`.
     interval_method : str, default 'bootstrapping'
         Technique used to estimate prediction intervals. Available options:
 
@@ -805,10 +804,6 @@ def backtesting_forecaster(
             f"types of forecasters use the other functions available in the "
             f"`model_selection` module."
         )
-    
-    # TODO: Remove in skforecast 0.25.0 when percentile support is removed.
-    if isinstance(interval, (list, tuple)):
-        interval = _normalize_interval_scale(interval)
     
     check_backtesting_input(
         forecaster              = forecaster,
@@ -1519,7 +1514,7 @@ def backtesting_forecaster_multiseries(
 
         **Changed in version 0.23.0:** `interval` is now expressed as
         quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-        is deprecated and emits a `FutureWarning`.
+        is not longer supported and will raise a `ValueError`.
     interval_method : str, default 'conformal'
         Technique used to estimate prediction intervals. Available options:
 
@@ -1636,10 +1631,6 @@ def backtesting_forecaster_multiseries(
                           exog              = exog,
                           exog_dict         = exog_dict
                       )
-    
-    # TODO: Remove in skforecast 0.25.0 when percentile support is removed.
-    if isinstance(interval, (list, tuple)):
-        interval = _normalize_interval_scale(interval)
 
     check_backtesting_input(
         forecaster              = forecaster,
@@ -2176,7 +2167,7 @@ def backtesting_stats(
 
         **Changed in version 0.23.0:** `interval` is now expressed as
         quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-        is deprecated and emits a `FutureWarning`.
+        is not longer supported and will raise a `ValueError`.
     freeze_params : bool, default True
         Determines whether to freeze the model parameters after the first fit
         for estimators that perform automatic model selection.
@@ -2247,10 +2238,6 @@ def backtesting_stats(
             "types of forecasters use the other functions available in the "
             "`model_selection` module."
         )
-    
-    # TODO: Remove in skforecast 0.25.0 when percentile support is removed.
-    if isinstance(interval, (list, tuple)):
-        interval = _normalize_interval_scale(interval)
     
     check_backtesting_input(
         forecaster        = forecaster,

--- a/skforecast/model_selection/tests/tests_validation/test_backtesting_forecaster_multiseries.py
+++ b/skforecast/model_selection/tests/tests_validation/test_backtesting_forecaster_multiseries.py
@@ -2119,10 +2119,10 @@ def test_output_backtesting_forecaster_multiseries_ForecasterRecursiveMultiSerie
     pd.testing.assert_frame_equal(predictions.head(10), expected_predictions)
 
 
-def test_output_backtesting_forecaster_multiseries_ForecasterRecursiveMultiSeries_series_and_exog_dict_interval_percentiles():
+def test_output_backtesting_forecaster_multiseries_ForecasterRecursiveMultiSeries_series_and_exog_dict_interval_quantiles():
     """
     Test output of backtesting_forecaster_multiseries in ForecasterRecursiveMultiSeries 
-    when series and exog are dictionaries, encoding='ordinal', and interval as percentiles.
+    when series and exog are dictionaries, encoding='ordinal', and interval as quantiles.
     (mocked done in Skforecast v0.15.0).
     """
     forecaster = ForecasterRecursiveMultiSeries(
@@ -4361,10 +4361,10 @@ def test_output_backtesting_forecaster_multiseries_ForecasterDirectMultiVariate_
     pd.testing.assert_frame_equal(expected_predictions, backtest_predictions)
 
 
-def test_output_backtesting_forecaster_multiseries_ForecasterDirectMultiVariate_no_refit_exog_interval_percentiles_with_mocked():
+def test_output_backtesting_forecaster_multiseries_ForecasterDirectMultiVariate_no_refit_exog_interval_quantiles_with_mocked():
     """
     Test output of backtesting_forecaster_multiseries in ForecasterDirectMultiVariate 
-    with no refit and gap with mocked using exog and intervals as percentiles
+    with no refit and gap with mocked using exog and intervals as quantiles
     (mocked done in Skforecast v0.15.0).
     """
     forecaster = ForecasterDirectMultiVariate(

--- a/skforecast/recursive/_forecaster_equivalent_date.py
+++ b/skforecast/recursive/_forecaster_equivalent_date.py
@@ -23,7 +23,6 @@ from ..utils import (
     check_y,
     check_predict_input,
     check_residuals_input,
-    _normalize_interval_scale,
     check_interval,
     check_extract_values_and_index,
     expand_index,
@@ -777,7 +776,7 @@ class ForecasterEquivalentDate():
 
             **Changed in version 0.23.0:** `interval` is now expressed as
             quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
+            is not longer supported and will raise a `ValueError`.
         use_in_sample_residuals : bool, default True
             If `True`, residuals from the training data are used as proxy of
             prediction error to create predictions. 
@@ -845,7 +844,6 @@ class ForecasterEquivalentDate():
         )
 
         if isinstance(interval, (list, tuple)):
-            interval = _normalize_interval_scale(interval)
             check_interval(
                 interval                   = interval,
                 ensure_symmetric_intervals = True

--- a/skforecast/recursive/_forecaster_recursive.py
+++ b/skforecast/recursive/_forecaster_recursive.py
@@ -38,7 +38,6 @@ from ..utils import (
     check_predict_input,
     check_residuals_input,
     check_interval,
-    _normalize_interval_scale,
     check_extract_values_and_index,
     configure_estimator_categorical_features,
     cast_catboost_categorical_columns,
@@ -2433,7 +2432,7 @@ class ForecasterRecursive(ForecasterBase):
 
             **Changed in version 0.23.0:** `interval` is now expressed as
             quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
+            is not longer supported and will raise a `ValueError`.
         n_boot : int, default 250
             Number of bootstrapping iterations to perform when estimating prediction
             intervals.
@@ -2476,7 +2475,6 @@ class ForecasterRecursive(ForecasterBase):
         if method == "bootstrapping":
             
             if isinstance(interval, (list, tuple)):
-                interval = _normalize_interval_scale(interval)
                 check_interval(interval=interval, ensure_symmetric_intervals=False)
                 interval = np.array(interval)
             else:
@@ -2509,7 +2507,6 @@ class ForecasterRecursive(ForecasterBase):
         elif method == 'conformal':
 
             if isinstance(interval, (list, tuple)):
-                interval = _normalize_interval_scale(interval)
                 check_interval(interval=interval, ensure_symmetric_intervals=True)
                 nominal_coverage = interval[1] - interval[0]
             else:

--- a/skforecast/recursive/_forecaster_recursive_multiseries.py
+++ b/skforecast/recursive/_forecaster_recursive_multiseries.py
@@ -48,7 +48,6 @@ from ..utils import (
     check_predict_input,
     check_residuals_input,
     check_interval,
-    _normalize_interval_scale,
     configure_estimator_categorical_features,
     cast_catboost_categorical_columns_dataframe,
     estimator_has_native_nan_support,
@@ -3561,7 +3560,7 @@ class ForecasterRecursiveMultiSeries(ForecasterBase):
 
             **Changed in version 0.23.0:** `interval` is now expressed as
             quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
+            is not longer supported and will raise a `ValueError`.
         n_boot : int, default 250
             Number of bootstrapping iterations to perform when estimating prediction
             intervals.
@@ -3602,7 +3601,6 @@ class ForecasterRecursiveMultiSeries(ForecasterBase):
         if method == "bootstrapping":
             
             if isinstance(interval, (list, tuple)):
-                interval = _normalize_interval_scale(interval)
                 check_interval(interval=interval, ensure_symmetric_intervals=False)
                 interval = np.array(interval)
             else:
@@ -3640,7 +3638,6 @@ class ForecasterRecursiveMultiSeries(ForecasterBase):
         elif method == 'conformal':
 
             if isinstance(interval, (list, tuple)):
-                interval = _normalize_interval_scale(interval)
                 check_interval(interval=interval, ensure_symmetric_intervals=True)
                 nominal_coverage = interval[1] - interval[0]
             else:

--- a/skforecast/recursive/_forecaster_stats.py
+++ b/skforecast/recursive/_forecaster_stats.py
@@ -26,7 +26,6 @@ from ..utils import (
     check_predict_input,
     expand_index,
     get_exog_dtypes,
-    _normalize_interval_scale,
     check_interval,
     transform_series,
     transform_numpy,
@@ -1053,7 +1052,7 @@ class ForecasterStats(MultiEstimatorMixin):
 
             **Changed in version 0.23.0:** `interval` is now expressed as
             quantiles (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
+            is not longer supported and will raise a `ValueError`.
         suppress_warnings : bool, default False
             If `True`, skforecast warnings will be suppressed during the prediction 
             process. See skforecast.exceptions.warn_skforecast_categories for more
@@ -1074,7 +1073,6 @@ class ForecasterStats(MultiEstimatorMixin):
 
         # If interval and alpha take alpha, if interval transform to alpha
         if alpha is None:
-            interval = _normalize_interval_scale(interval=interval)
             check_interval(
                 interval                   = interval,
                 ensure_symmetric_intervals = True

--- a/skforecast/recursive/tests/tests_forecaster_recursive/test_predict_interval.py
+++ b/skforecast/recursive/tests/tests_forecaster_recursive/test_predict_interval.py
@@ -29,29 +29,6 @@ def test_check_interval_ValueError_when_method_is_not_valid_method():
         forecaster.predict_interval(steps=1, method=method)
 
 
-# TODO: Remove in skforecast 0.25.0 when percentile support is removed.
-@pytest.mark.parametrize("method", 
-                         ['bootstrapping', 'conformal'], 
-                         ids = lambda value: f'method: {value}')
-def test_predict_interval_percentile_and_quantile_scales_are_equivalent(method):
-    """
-    Check that the legacy percentile scale [5, 95] produces the same output as
-    the new quantile scale [0.05, 0.95].
-    """
-    forecaster = ForecasterRecursive(LinearRegression(), lags=3)
-    forecaster.fit(y=pd.Series(np.arange(10)), store_in_sample_residuals=True)
-
-    with pytest.warns(FutureWarning):
-        results_percentile = forecaster.predict_interval(
-            steps=3, method=method, interval=[5, 95], use_binned_residuals=False
-        )
-    results_quantile = forecaster.predict_interval(
-        steps=3, method=method, interval=[0.05, 0.95], use_binned_residuals=False
-    )
-
-    pd.testing.assert_frame_equal(results_percentile, results_quantile)
-
-
 def test_predict_interval_output_when_forecaster_is_LinearRegression_steps_is_1_in_sample_residuals_is_True():
     """
     Test output when estimator is LinearRegression and one step ahead is predicted

--- a/skforecast/stats/_arar.py
+++ b/skforecast/stats/_arar.py
@@ -22,7 +22,7 @@ from ._utils import (
     check_is_fitted, 
     check_memory_reduced, 
     FastLinearRegression,
-    _normalize_level
+    check_level
 )
 
 
@@ -454,10 +454,6 @@ class Arar(BaseEstimator, RegressorMixin):
         level : float, list or tuple of float, default (0.8, 0.95)
             Confidence levels expressed as coverage proportions in the (0, 1]
             range (e.g., 0.8 for 80% intervals).
-
-            **Changed in version 0.23.0:** `level` is now expressed as coverage
-            proportions (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
         as_frame : bool, default True
             If True, return a tidy DataFrame with columns 'mean', 'lower_<L>',
             'upper_<L>' for each level L. If False, return a NumPy ndarray.
@@ -481,7 +477,7 @@ class Arar(BaseEstimator, RegressorMixin):
         if not isinstance(steps, (int, np.integer)) or steps <= 0:
             raise ValueError("`steps` must be a positive integer.")
 
-        level = _normalize_level(level)
+        level = check_level(level)
         level_pct = [lv * 100 for lv in level]
         raw_preds = forecast(self.model_, h=steps, level=level_pct)
         

--- a/skforecast/stats/_arima.py
+++ b/skforecast/stats/_arima.py
@@ -14,7 +14,7 @@ from sklearn.base import BaseEstimator, RegressorMixin
 
 from .arima._arima_base import arima, predict_arima
 from .arima._auto_arima import auto_arima, forecast_arima
-from ._utils import check_is_fitted, check_memory_reduced, _normalize_level
+from ._utils import check_is_fitted, check_memory_reduced, check_level
 
 
 class Arima(BaseEstimator, RegressorMixin):
@@ -685,10 +685,6 @@ class Arima(BaseEstimator, RegressorMixin):
             Confidence levels expressed as coverage proportions in the (0, 1]
             range (e.g., 0.8 for 80% intervals). If None and `alpha` is None,
             defaults to (0.8, 0.95). Cannot be specified together with `alpha`.
-
-            **Changed in version 0.23.0:** `level` is now expressed as coverage
-            proportions (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
         alpha : float, default None
             The significance level for the prediction interval. 
             If specified, the confidence interval will be (1 - alpha) * 100%.
@@ -735,7 +731,7 @@ class Arima(BaseEstimator, RegressorMixin):
         elif level is None:
             level = (0.8, 0.95)
         
-        level = _normalize_level(level)
+        level = check_level(level)
         
         if exog is not None:
             exog = np.asarray(exog, dtype=float)

--- a/skforecast/stats/_ets.py
+++ b/skforecast/stats/_ets.py
@@ -17,7 +17,7 @@ from .exponential_smoothing._ets_base import (
     auto_ets,
     forecast_ets
 )
-from ._utils import check_is_fitted, check_memory_reduced, _normalize_level
+from ._utils import check_is_fitted, check_memory_reduced, check_level
 
 
 class Ets(BaseEstimator, RegressorMixin):
@@ -405,10 +405,6 @@ class Ets(BaseEstimator, RegressorMixin):
         level : list or tuple of float, default (0.8, 0.95)
             Confidence levels expressed as coverage proportions in the (0, 1]
             range (e.g., 0.8 for 80% intervals).
-
-            **Changed in version 0.23.0:** `level` is now expressed as coverage
-            proportions (0-1) instead of percentiles (0-100). Passing percentiles
-            is deprecated and emits a `FutureWarning`.
         as_frame : bool, default True
             If True, return a tidy DataFrame with columns 'mean', 'lower_<L>',
             'upper_<L>' for each level L. If False, return a NumPy ndarray.
@@ -426,7 +422,7 @@ class Ets(BaseEstimator, RegressorMixin):
         if not isinstance(steps, (int, np.integer)) or steps <= 0:
             raise ValueError("`steps` must be a positive integer.")
 
-        level = _normalize_level(level)
+        level = check_level(level)
         level_pct = [lv * 100 for lv in level]
 
         raw_preds = forecast_ets(

--- a/skforecast/stats/_utils.py
+++ b/skforecast/stats/_utils.py
@@ -6,35 +6,27 @@
 
 
 from __future__ import annotations
-import warnings
 import numpy as np
 from sklearn.exceptions import NotFittedError
 
 
-def _normalize_level(
+def check_level(
     level: float | int | list[float] | tuple[float, ...]
 ) -> list[float]:
     """
-    Normalize confidence level(s) to the 0-1 coverage scale.
-
-    Detection rules, applied to the level value(s):
-
-    - All values in `(0, 1]`: already coverage proportions, returned unchanged.
-    - All values in `(1, 100]`: legacy percentiles. They are divided by 100 and
-    a `FutureWarning` is emitted.
-    - Mixed (some value `<= 1` and some value `> 1`): the scale is ambiguous and
-    a `ValueError` is raised.
+    Check that the confidence level(s) are valid coverage proportions and
+    return them as a list of floats.
 
     Parameters
     ----------
     level : float, int, list, tuple
-        Confidence level(s), either as coverage proportions (0-1) or as legacy
-        percentiles (0-100).
+        Confidence level(s) expressed as coverage proportions in the `(0, 1]`
+        range. For example, `0.8` for 80% intervals.
 
     Returns
     -------
     level : list
-        Confidence level(s) expressed as coverage proportions in the 0-1 scale.
+        Confidence level(s) as a list of floats.
 
     """
 
@@ -43,24 +35,11 @@ def _normalize_level(
     else:
         values = [float(v) for v in level]
 
-    any_above_one = any(v > 1 for v in values)
-    any_le_one = any(v <= 1 for v in values)
-
-    if any_above_one and any_le_one:
+    if any(v <= 0. or v > 1. for v in values):
         raise ValueError(
-            "`level` mixes values <= 1 and > 1, so the scale is ambiguous. Use "
-            "coverage proportions in the (0, 1] range, e.g. `level=[0.8, 0.95]`."
+            f"All values in `level` must be coverage proportions in the (0, 1] "
+            f"range, e.g. `level=[0.8, 0.95]`. Got {level}."
         )
-
-    if any_above_one:
-        warnings.warn(
-            "Passing `level` as percentiles (0-100) is deprecated. Use coverage "
-            "proportions (0-1) instead. For example, use `level=[0.8, 0.95]` "
-            "instead of `level=[80, 95]`. Percentile support will be removed in "
-            "skforecast 0.25.0.",
-            FutureWarning
-        )
-        return [v / 100 for v in values]
 
     return values
 

--- a/skforecast/stats/tests/tests_arima/test_predict_interval.py
+++ b/skforecast/stats/tests/tests_arima/test_predict_interval.py
@@ -525,24 +525,19 @@ def test_predict_interval_with_exog_dataframe():
 
 def test_predict_interval_level_as_single_value():
     """
-    Test predict_interval with level as single int or float (not tuple).
+    Test predict_interval with level as a single float (not tuple).
     """
     y = ar1_series(100, seed=42)
     model = Arima(order=(1, 0, 1), seasonal_order=(0, 0, 0))
     model.fit(y)
-    
-    # Test with single int
-    result_int = model.predict_interval(steps=5, level=90)
-    assert 'lower_0.9' in result_int.columns
-    assert 'upper_0.9' in result_int.columns
-    assert len([c for c in result_int.columns if 'lower' in c]) == 1
-    
-    # Test with single float
-    result_float = model.predict_interval(steps=5, level=85.0)
-    assert 'lower_0.85' in result_float.columns
-    assert 'upper_0.85' in result_float.columns
-    
-    # Check exact values for level=90
+
+    result_85 = model.predict_interval(steps=5, level=0.85)
+    assert 'lower_0.85' in result_85.columns
+    assert 'upper_0.85' in result_85.columns
+    assert len([c for c in result_85.columns if 'lower' in c]) == 1
+
+    # Check exact values for level=0.9
+    result_90 = model.predict_interval(steps=5, level=0.9)
     expected_mean = np.array([
         -1.60969915, -1.11552107, -0.78835957, -0.57176833, -0.42837809
     ])
@@ -553,9 +548,9 @@ def test_predict_interval_level_as_single_value():
         -0.3430204 ,  0.47730986,  0.92799446,  1.19600576,  1.36147714
     ])
     
-    np.testing.assert_array_almost_equal(result_int['mean'].values, expected_mean, decimal=4)
-    np.testing.assert_array_almost_equal(result_int['lower_0.9'].values, expected_lower_90, decimal=4)
-    np.testing.assert_array_almost_equal(result_int['upper_0.9'].values, expected_upper_90, decimal=4)
+    np.testing.assert_array_almost_equal(result_90['mean'].values, expected_mean, decimal=4)
+    np.testing.assert_array_almost_equal(result_90['lower_0.9'].values, expected_lower_90, decimal=4)
+    np.testing.assert_array_almost_equal(result_90['upper_0.9'].values, expected_upper_90, decimal=4)
 
 
 def test_predict_interval_exog_errors():

--- a/skforecast/stats/tests/tests_utils/test_check_level.py
+++ b/skforecast/stats/tests/tests_utils/test_check_level.py
@@ -1,0 +1,42 @@
+# Unit test check_level
+# ==============================================================================
+import re
+import pytest
+import numpy as np
+
+from skforecast.stats._utils import check_level
+
+
+@pytest.mark.parametrize("level, expected",
+                         [(0.8, [0.8]),
+                          (1, [1.0]),
+                          (np.float64(0.95), [0.95]),
+                          ([0.8, 0.95], [0.8, 0.95]),
+                          ((0.025, 0.975), [0.025, 0.975]),
+                          (np.array([0.5, 0.9]), [0.5, 0.9])],
+                         ids = lambda value: f'level: {value}')
+def test_check_level_output_when_valid_coverage_proportions(level, expected):
+    """
+    Test check_level returns a list of floats when `level` is within (0, 1].
+    """
+    results = check_level(level)
+
+    assert results == expected
+    assert all(isinstance(v, float) for v in results)
+
+
+@pytest.mark.parametrize("level",
+                         [90, [80, 95], (95,), 0, -0.1, [0.9, 95]],
+                         ids = lambda value: f'level: {value}')
+def test_check_level_ValueError_when_level_is_out_of_range(level):
+    """
+    Test ValueError is raised when `level` is outside the (0, 1] range, for
+    example when given as percentiles. Support for percentiles was removed in
+    skforecast 0.25.0.
+    """
+    err_msg = re.escape(
+        f"All values in `level` must be coverage proportions in the (0, 1] "
+        f"range, e.g. `level=[0.8, 0.95]`. Got {level}."
+    )
+    with pytest.raises(ValueError, match = err_msg):
+        check_level(level)

--- a/skforecast/utils/__init__.py
+++ b/skforecast/utils/__init__.py
@@ -2,6 +2,5 @@ from .utils import *
 from .utils import (
     _build_predict_function,
     _get_estimator_categorical_set_params,
-    _normalize_interval_scale,
     _restore_estimator_categorical_set_params
 )

--- a/skforecast/utils/tests/tests_utils/test_check_interval.py
+++ b/skforecast/utils/tests/tests_utils/test_check_interval.py
@@ -3,7 +3,6 @@
 import re
 import pytest
 from skforecast.utils import check_interval
-from skforecast.utils.utils import _normalize_interval_scale
 
 
 def test_check_interval_TypeError_when_interval_is_not_a_list():
@@ -197,46 +196,13 @@ def test_check_interval_quantile_scale_ValueError_when_not_symmetric():
         )
 
 
-@pytest.mark.parametrize("interval, expected",
-                         [([0.05, 0.95], [0.05, 0.95]),
-                          ((0.025, 0.975), [0.025, 0.975]),
-                          ([0.0, 1.0], [0.0, 1.0])],
-                         ids = lambda value: f'{value}')
-def test_normalize_interval_scale_quantiles_unchanged(interval, expected):
-    """
-    Check values already in the 0-1 scale are returned unchanged.
-    """
-    results = _normalize_interval_scale(interval)
-    assert results == expected
-
-
-def test_normalize_interval_scale_percentiles_converted_with_warning():
-    """
-    Check legacy percentiles (all > 1) are divided by 100 and a `FutureWarning`
-    is emitted.
-    """
-    err_msg = re.escape(
-        "Passing `interval` as percentiles (0-100) is deprecated. Use "
-        "quantiles (0-1) instead. For example, use `interval=[0.05, 0.95]` "
-        "instead of `interval=[5, 95]`. Percentile support will be removed "
-        "in skforecast 0.25.0."
-    )
-    with pytest.warns(FutureWarning, match = err_msg):
-        results = _normalize_interval_scale([5, 95])
-
-    assert results == [0.05, 0.95]
-
-
 @pytest.mark.parametrize("interval",
-                         [[1, 50], [0.5, 95], (1.0, 97.5)],
+                         [[5, 95], (2.5, 97.5), [0.5, 95]],
                          ids = lambda value: f'interval: {value}')
-def test_normalize_interval_scale_ValueError_when_mixed(interval):
+def test_check_interval_ValueError_when_interval_is_a_percentile(interval):
     """
-    Check `ValueError` is raised when interval mixes values <= 1 and > 1.
+    Check `ValueError` is raised when `interval` is given as percentiles. Support
+    for percentiles was removed in skforecast 0.25.0.
     """
-    err_msg = re.escape(
-        "`interval` mixes values <= 1 and > 1, so the scale is ambiguous. "
-        "Use quantiles in the [0, 1] range, e.g. `interval=[0.05, 0.95]`."
-    )
-    with pytest.raises(ValueError, match = err_msg):
-        _normalize_interval_scale(interval)
+    with pytest.raises(ValueError, match = 'interval bound'):
+        check_interval(interval=interval)

--- a/skforecast/utils/utils.py
+++ b/skforecast/utils/utils.py
@@ -1036,61 +1036,6 @@ def check_exog_dtypes(
                 )
 
 
-# TODO: Remove in skforecast 0.25.0 when percentile support is removed.
-def _normalize_interval_scale(
-    interval: list[float] | tuple[float]
-) -> list[float]:
-    """
-    Normalize a 2-value interval to the 0-1 quantile scale.
-
-    Detection rules, given the two interval bounds:
-
-    - All values in `[0, 1]`: already quantiles, returned unchanged.
-    - All values in `(1, 100]`: legacy percentiles. They are divided by 100
-    and a `FutureWarning` is emitted.
-    - Mixed (some value `<= 1` and some value `> 1`): the scale is ambiguous
-    and a `ValueError` is raised.
-
-    The value exactly `1` is treated as a quantile (valid upper bound), unless
-    it appears together with another value `> 1` (then it is considered mixed
-    and a `ValueError` is raised).
-
-    Parameters
-    ----------
-    interval : list, tuple
-        Sequence of two interval bounds, either as quantiles (0-1) or as legacy
-        percentiles (0-100).
-
-    Returns
-    -------
-    interval : list
-        Interval bounds expressed as quantiles in the 0-1 scale.
-
-    """
-
-    values = list(interval)
-    any_above_one = any(v > 1 for v in values)
-    any_le_one = any(v <= 1 for v in values)
-
-    if any_above_one and any_le_one:
-        raise ValueError(
-            "`interval` mixes values <= 1 and > 1, so the scale is ambiguous. "
-            "Use quantiles in the [0, 1] range, e.g. `interval=[0.05, 0.95]`."
-        )
-
-    if any_above_one:
-        warnings.warn(
-            "Passing `interval` as percentiles (0-100) is deprecated. Use "
-            "quantiles (0-1) instead. For example, use `interval=[0.05, 0.95]` "
-            "instead of `interval=[5, 95]`. Percentile support will be removed "
-            "in skforecast 0.25.0.",
-            FutureWarning
-        )
-        return [v / 100 for v in values]
-
-    return [float(v) for v in values]
-
-
 def check_interval(
     interval: list[float] | tuple[float] | None = None,
     ensure_symmetric_intervals: bool = False,

--- a/tests/test_skforecast_version.py
+++ b/tests/test_skforecast_version.py
@@ -3,7 +3,7 @@
 from skforecast import __version__
 import tomli
 
-version = "0.24.0"
+version = "0.25.0"
 
 
 def test_version_in_init_and_pyproject_toml():

--- a/tools/ai/llms-base.txt
+++ b/tools/ai/llms-base.txt
@@ -2,13 +2,13 @@
 
 > Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models
 
-This document is for skforecast v0.24.0+. If you are using an older version, check the documentation at skforecast.org.
+This document is for skforecast v0.25.0+. If you are using an older version, check the documentation at skforecast.org.
 
 Skforecast is a Python library for time series forecasting using scikit-learn compatible models, statistical methods, and foundation models. It works with any estimator compatible with the scikit-learn API (LightGBM, XGBoost, CatBoost, Keras, etc.).
 
 ## Quick Info
 
-- Version: 0.24.0
+- Version: 0.25.0
 - License: BSD-3-Clause
 - Python: 3.10, 3.11, 3.12, 3.13, 3.14
 - Repository: https://github.com/skforecast/skforecast
@@ -670,5 +670,5 @@ show_datasets_info()
 ## Citation
 
 ```
-Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.24.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
+Amat Rodrigo, J., & Escobar Ortiz, J. (2026). skforecast (Version 0.25.0) [Computer software]. https://doi.org/10.5281/zenodo.8382787
 ```


### PR DESCRIPTION
- Updated version number in llms-full.txt, llms.txt, pyproject.toml, __init__.py, and other relevant files to reflect the new version 0.25.0.
- Changed documentation references from version 0.24.0 to 0.25.0.
- Removed deprecated support for percentile intervals in various forecaster classes and utility functions, ensuring all interval inputs are now expected as quantiles (0-1).
- Updated tests to reflect changes in interval handling and removed tests related to deprecated percentile support.
- Added new utility function `check_level` to validate confidence levels as coverage proportions.