### PR TITLE
Enhance NoriAdapter to support multiple model IDs and update document…

### DIFF
--- a/docs/user_guides/foundation-forecasting-models.ipynb
+++ b/docs/user_guides/foundation-forecasting-models.ipynb
@@ -605,7 +605,7 @@
     "            Docs <svg class=\"external-icon\" width=\"12\" height=\"12\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" viewBox=\"0 0 24 24\"><path d=\"M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14\"></path></svg>\n",
     "          </a>\n",
     "        </td>\n",
-    "        <td>Synthefy/Nori</td>\n",
+    "        <td>Synthefy/Nori<br>Synthefy/Nori-30M<br>Synthefy/Nori-100M</td>\n",
     "        <td>PyTorch</td>\n",
     "        <td>4096</td>\n",
     "        <td>No hard limit</td>\n",

--- a/skforecast/foundation/_adapters.py
+++ b/skforecast/foundation/_adapters.py
@@ -3331,9 +3331,10 @@ class NoriAdapter:
     Parameters
     ----------
     model_id : str
-        Model ID, e.g. `"Synthefy/Nori"`. Used to resolve this adapter; the
-        underlying checkpoint is controlled by `nori_config` (key `model_path`)
-        and defaults to the public HuggingFace checkpoint.
+        Model ID, e.g. `"Synthefy/Nori"` (6M), `"Synthefy/Nori-30M"` or
+        `"Synthefy/Nori-100M"`. Used to resolve this adapter and, unless
+        overridden in `nori_config`, to select the checkpoint downloaded from
+        HuggingFace.
     model : object, default None
         Pre-instantiated `NoriRegressor` instance. If `None`, a new instance
         is created lazily on the first call to `predict`. Intended for testing
@@ -3356,9 +3357,11 @@ class NoriAdapter:
         weekly cycles for datetime series (or on the running index for
         `RangeIndex` series). Set `0` to disable. Must be a non-negative integer.
     nori_config : dict, default None
-        Additional keyword arguments forwarded verbatim to `NoriRegressor` at
-        instantiation (e.g. `model_path`, `device`, `token`, `augmentations`).
-        If `None`, the library defaults are used.
+        Keyword arguments forwarded verbatim to `NoriRegressor` at instantiation
+        (e.g. `device`, `token`, `augmentations`). The checkpoint defaults to
+        `model_id` and can be overridden here with `model` (a registry name such
+        as `'nori-6m'` or a HuggingFace repo id) or `model_path` (a local
+        checkpoint file, which takes precedence over `model`).
 
     Attributes
     ----------
@@ -3449,8 +3452,9 @@ class NoriAdapter:
             Number of Fourier seasonal harmonics added. Set `0` to disable.
             Must be a non-negative integer.
         nori_config : dict, default None
-            Additional keyword arguments forwarded verbatim to `NoriRegressor`
-            at instantiation.
+            Keyword arguments forwarded verbatim to `NoriRegressor` at
+            instantiation. The checkpoint defaults to `model_id` and can be
+            overridden here with `model` or `model_path`.
 
         """
 
@@ -3725,7 +3729,13 @@ class NoriAdapter:
                 "Install it with `pip install synthefy-nori`."
             ) from exc
 
-        self._model = NoriRegressor(**self.nori_config)
+        # synthefy-nori has no default checkpoint. Its `model` argument accepts
+        # either a registry name ('nori-6m') or a raw HuggingFace repo id, so
+        # `model_id` is passed through. It is ignored when `model_path` is set.
+        config = dict(self.nori_config)
+        config.setdefault("model", self.model_id)
+
+        self._model = NoriRegressor(**config)
 
     @staticmethod
     def _to_numpy(values: Any) -> np.ndarray:

--- a/skforecast/foundation/_foundation_model.py
+++ b/skforecast/foundation/_foundation_model.py
@@ -68,6 +68,8 @@ class FoundationModel:
         Synthefy Nori (supports `exog`):
 
         - `'Synthefy/Nori'`
+        - `'Synthefy/Nori-30M'`
+        - `'Synthefy/Nori-100M'`
 
         EDF Lab TS-ICL (supports `exog`):
 

--- a/skforecast/foundation/tests/tests_foundation_models/fixtures_adapters.py
+++ b/skforecast/foundation/tests/tests_foundation_models/fixtures_adapters.py
@@ -495,6 +495,7 @@ class FakeNoriRegressor:
     """
 
     def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
         self.n_features_in_ = None
         self.y_ = None
         self.last_output_type = None

--- a/skforecast/foundation/tests/tests_foundation_models/test_NoriAdapter.py
+++ b/skforecast/foundation/tests/tests_foundation_models/test_NoriAdapter.py
@@ -1,6 +1,8 @@
 # Unit test NoriAdapter
 # ==============================================================================
 import re
+import sys
+import types
 import pytest
 import numpy as np
 import pandas as pd
@@ -445,3 +447,49 @@ def test_NoriAdapter_load_model_ImportError_when_backend_missing(monkeypatch):
     adapter.fit({"sales": y}, None)
     with pytest.raises(ImportError, match=re.escape("synthefy-nori is required")):
         adapter.predict(3, {"sales": y}, None, None, None)
+
+
+def test_NoriAdapter_load_model_passes_model_id_as_checkpoint(monkeypatch):
+    """
+    Test that _load_model forwards `model_id` as the `model` argument, since
+    synthefy-nori has no default checkpoint and accepts raw repo ids.
+    """
+    fake_backend = types.ModuleType("synthefy_nori")
+    fake_backend.NoriRegressor = FakeNoriRegressor
+    monkeypatch.setitem(sys.modules, "synthefy_nori", fake_backend)
+
+    adapter = NoriAdapter(model_id="Synthefy/Nori-30M")
+    adapter._load_model()
+
+    assert adapter._model.init_kwargs == {"model": "Synthefy/Nori-30M"}
+
+
+@pytest.mark.parametrize(
+    "nori_config, expected",
+    [
+        ({"model": "nori-6m"}, {"model": "nori-6m"}),
+        (
+            {"model_path": "/path/to/model.pt"},
+            {"model_path": "/path/to/model.pt", "model": "Synthefy/Nori"},
+        ),
+        ({"device": "cpu"}, {"device": "cpu", "model": "Synthefy/Nori"}),
+    ],
+    ids=["model", "model_path", "other_config"],
+)
+def test_NoriAdapter_load_model_nori_config_overrides_model_id(
+    nori_config, expected, monkeypatch
+):
+    """
+    Test that `model` in `nori_config` overrides `model_id`, that other keys
+    are forwarded verbatim, and that `nori_config` is not mutated.
+    """
+    fake_backend = types.ModuleType("synthefy_nori")
+    fake_backend.NoriRegressor = FakeNoriRegressor
+    monkeypatch.setitem(sys.modules, "synthefy_nori", fake_backend)
+
+    original_config = dict(nori_config)
+    adapter = NoriAdapter(model_id="Synthefy/Nori", nori_config=nori_config)
+    adapter._load_model()
+
+    assert adapter._model.init_kwargs == expected
+    assert adapter.nori_config == original_config


### PR DESCRIPTION
…ation

- Updated the NoriAdapter class to accept additional model IDs: "Synthefy/Nori-30M" and "Synthefy/Nori-100M".
- Modified the documentation to reflect the new model ID options.
- Adjusted the logic in the _load_model method to correctly pass the model ID as a checkpoint.
- Added unit tests to verify the correct behavior of model ID handling and configuration overrides.