### PR TITLE
Validate interval length upfront when interval_method is conformal in backtesting

### DIFF
--- a/skforecast/model_selection/_utils.py
+++ b/skforecast/model_selection/_utils.py
@@ -413,6 +413,15 @@ def check_backtesting_input(
                         f"be a float or a list/tuple defining a symmetric interval. "
                         f"Got {type(interval)}."
                     )
+                if isinstance(interval, (list, tuple)) and len(interval) != 2:
+                    raise ValueError(
+                        f"When `interval_method` is 'conformal', `interval` must be "
+                        f"a float or a list/tuple of exactly 2 values (lower and "
+                        f"upper quantile) defining a symmetric interval. Multiple "
+                        f"quantiles (e.g. `interval=[0.1, 0.5, 0.9]`) are only "
+                        f"supported when `interval_method='bootstrapping'`. "
+                        f"Got {interval}."
+                    )
             elif interval_method == 'bootstrapping':
                 if (
                     not isinstance(interval, (float, list, tuple, str))

--- a/skforecast/model_selection/tests/tests_utils/test_check_backtesting_input.py
+++ b/skforecast/model_selection/tests/tests_utils/test_check_backtesting_input.py
@@ -862,6 +862,19 @@ def test_check_backtesting_input_raises_when_interval_not_None_and_interval_meth
     with pytest.raises(TypeError, match = err_msg):
         check_backtesting_input(**kwargs)
 
+    kwargs['interval'] = [0.1, 0.5, 0.9]
+    kwargs['interval_method'] = 'conformal'
+    err_msg = re.escape(
+        "When `interval_method` is 'conformal', `interval` must be "
+        "a float or a list/tuple of exactly 2 values (lower and "
+        "upper quantile) defining a symmetric interval. Multiple "
+        "quantiles (e.g. `interval=[0.1, 0.5, 0.9]`) are only "
+        "supported when `interval_method='bootstrapping'`. "
+        "Got [0.1, 0.5, 0.9]."
+    )
+    with pytest.raises(ValueError, match = err_msg):
+        check_backtesting_input(**kwargs)
+
     kwargs['interval'] = {'10': 0.1, '90': 0.9}
     kwargs['interval_method'] = 'bootstrapping'
     err_msg = re.escape(


### PR DESCRIPTION
**Validate interval length upfront when interval_method is conformal in backtesting**

- Added an explicit check in `check_backtesting_input` that raises a `ValueError` immediately, before any fold runs, with a message that names the actual problem and points to the fix (`interval_method='bootstrapping'`).

- Added a test case in `test_check_backtesting_input_raises_when_interval_not_None_and_interval_method` covering `interval=[0.1, 0.5, 0.9]` + `interval_method='conformal'`.